### PR TITLE
CachePlugin: lazy hive initialization

### DIFF
--- a/lib/plugins/cache.js
+++ b/lib/plugins/cache.js
@@ -29,6 +29,7 @@ exports.CachePlugin = comb.define(null, {
         constructor:function () {
             this._super(arguments);
             this.post("load", this._postLoad);
+            this._static.initHive();
         },
 
         reload:function () {
@@ -62,8 +63,7 @@ exports.CachePlugin = comb.define(null, {
     },
 
     static:{
-
-        init:function () {
+        initHive:function () {
             if (!hive) {
                 hive = new Hive();
             }

--- a/test/plugins/cachePlugin.test.js
+++ b/test/plugins/cachePlugin.test.js
@@ -70,11 +70,16 @@ it.describe("Model with cache plugin", function (it) {
         Model = patio.addModel(mockDb.from("cache"), {
             plugins:[patio.plugins.CachePlugin]
         });
+        
         return patio.syncModels();
     });
 
     it.beforeEach(function () {
         mockDb.reset();
+    });
+    
+    it.afterEach(function() {
+        // Flush after each test to let the hive initialize during the first test
         Model.cache.flushAll();
     });
 


### PR DESCRIPTION
This patch allows the hive not to be initialized until strictly needed: i.e. a Model instance actually needs it.

What motivated it is that this simple node.js script:

```
var patio = require('patio');
```

 won't ever return to shell, as the hive is never killed. It's also annoying when trying to use patio from within Jake (https://github.com/mde/jake/) and your jakefile's execution never returns to shell.

The problem lies in the cleanup interval set on hive/lib/hive.js:50 :

```
this.__cleanupInterval = setInterval(comb.hitch(this, this._checkValues), this.__checkInterval);
```

That timer is never stopped and therefore doesn't allow that simple script to gracefully exit.

This pull request only solves the problem if you are not using the cache plugin (my case). It is still your responsibility to clear the interval if you are using the plugin and want your application to successfully stop.
