### PR TITLE
Custom getters

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -265,8 +265,11 @@ var Model = comb.define([QueryPlugin, comb.plugins.Middleware], {
         },
 
         _getColumnValue:function (name) {
-            var ret = this.__values[name];
-            return ret;
+            var val = this.__values[name];
+            var getterFunc = this["_get" + name.charAt(0).toUpperCase() + name.substr(1)];
+            var columnValue = comb.isFunction(getterFunc) ? getterFunc.call(this, val) : val;
+            
+            return columnValue;
         },
 
         _setColumnValue:function (name, val) {


### PR DESCRIPTION
This feature allows you to put a custom getter to make some transformation to the returning value before it is actually returned. The syntax and concept is similar to custom setters.

Example:

```
var User = patio.addModel("user", {
    instance : {
        _getFirstName : function(firstName){
            // First name must be always returned as uppercase
            return firstName.toUpperCase();
        }    
    }
});
```
