### PR TITLE
Slight correction to andGroupedOr allowing it to be called on a dataset ...

### DIFF
--- a/lib/dataset/query.js
+++ b/lib/dataset/query.js
@@ -161,7 +161,8 @@ define(null, {
         },
 
         /**
-         * Adds to the where/having clause with an AND a group of ORed conditions wrapped in parens
+         * Adds to the where/having clause with an AND a group of ORed conditions wrapped in parens. If there isn't an
+         * existing where/having clause on the ds, a where clause will be added, with each condition being ORed.
          *
          * <p>
          *     <b>For parameter types see {@link patio.Dataset#filter}.</b>
@@ -169,6 +170,7 @@ define(null, {
          *
          * @example
          *
+         * With prior filter:
          * DB.from("items").filter({id, [1,2,3]}).andGroupedOr([{price: {lt : 0}}, {price: {gt: 10}]).sql;
          *      //=> SELECT
          *               *
@@ -177,22 +179,32 @@ define(null, {
          *           WHERE
          *               ((id IN (1, 2, 3)) AND ((price < 0) OR (price > 10)))
          *
-         * @throws {patio.QueryError} If no WHERE?HAVING clause exists.
+         * Without prior filter:
+         * DB.from("items").andGroupedOr([{price: {lt : 0}}, {price: {gt: 10}]).sql;
+         *      //=> SELECT
+         *               *
+         *           FROM
+         *               items
+         *           WHERE
+         *               ((price < 0) OR (price > 10))
+         *
          * @return {patio.Dataset} a cloned dataset with the condition 'or group' added to the WHERE/HAVING clause.
          */
         andGroupedOr:function () {
             var tOpts = this.__opts,
                 clause = (tOpts.having ? "having" : "where"),
                 clauseObj = tOpts[clause];
+            var args = argsToArray(arguments);
+            args = args.length == 1 ? args[0] : args;
+            var opts = {};
             if (clauseObj) {
-                var args = argsToArray(arguments);
-                args = args.length == 1 ? args[0] : args;
                 var opts = {};
                 opts[clause] = new BooleanExpression("AND", clauseObj, BooleanExpression.fromValuePairs(args,"OR"));
-                return this.mergeOptions(opts);
             } else {
-                throw new QueryError("No existing filter found");
+                var opts = {};
+                opts[clause] = BooleanExpression.fromValuePairs(args,"OR");
             }
+            return this.mergeOptions(opts);
         },
 
         /**

--- a/test/dataset/query.test.js
+++ b/test/dataset/query.test.js
@@ -458,8 +458,8 @@ it.describe("Dataset queries",function (it) {
         var dataset = new Dataset().from("test"),
             d1 = dataset.where({x:1});
 
-        it.should("raise if no filter exists", function () {
-            assert.throws(comb.hitch(dataset, "andGroupedOr", [{a:1},{y:2}]));
+        it.should("build a new where clause with each argument ORed if there isn't already a clause for the ds", function () {
+            assert.equal(dataset.andGroupedOr([{a:1},{b:2},{c:3}]).sql, "SELECT * FROM test WHERE ((a = 1) OR (b = 2) OR (c = 3))");
         });
 
         it.should("add an alternate expression of ORed conditions wrapped in parens to the where clause", function () {


### PR DESCRIPTION
...which doesn't already have a where/having clause. In this case, it will just add the ORed conditions to a new where clause

If you think it makes sense, I can also make this change to the orGroupedAnd method also, otherwise, this is ready to go, and will fix the issue with C2FO's api tests.
