### PR TITLE
Using stirngToIdentifier on hash keys in select() for doing aliases

### DIFF
--- a/lib/dataset/query.js
+++ b/lib/dataset/query.js
@@ -1633,7 +1633,7 @@ define(null, {
             columns.forEach(function (c) {
                 if (isHash(c)) {
                     for (var i in c) {
-                        select.push(new AliasedExpression(new Identifier(i), c[i]));
+                        select.push(new AliasedExpression(this.stringToIdentifier(i), c[i]));
                     }
                 } else if (isString(c)) {
                     select.push(this.stringToIdentifier(c));

--- a/test/dataset/query.test.js
+++ b/test/dataset/query.test.js
@@ -903,6 +903,7 @@ it.describe("Dataset queries",function (it) {
 
         it.should("accept a hash for AS values", function () {
             assert.equal(dataset.select({name: 'n', "__ggh": 'age'}).sql, "SELECT name AS n, __ggh AS age FROM test");
+            assert.equal(dataset.select({test__name: "n"}).sql, 'SELECT test.name AS n FROM test');
         });
 
         it.should("accept arbitrary objects and literalize them correctly", function () {


### PR DESCRIPTION
This fixes `dataset.select({table__column: "aliasName"}).sql` -> `SELECT table__column AS aliasName FROM test`.  

I realize there are other ways to accomplish this, in fact I ended up using "table__column___alias" for what I was doing, but this is the first thing I tried for some reason. Fixing just in case others try this method as well.   
