### PR TITLE
Patio migrate missingArgument undefined

### DIFF
--- a/bin/patio
+++ b/bin/patio
@@ -30,9 +30,10 @@ program.command("migrate")
     .option('--camelize [boolean]', 'force camel casing', false)
     .option('-us, --underscore [boolean]', 'force underscore', false)
     .action(function (program) {
+        var self = this;
         ["directory", "uri"].forEach(function (arg) {
             if (comb.isUndefined(program[arg])) {
-                program.missingArgument(arg);
+                self.missingArgument(arg);
             }
         });
 


### PR DESCRIPTION
If you run `patio migrate blah` you get a missArgument undefined error.
