### PR TITLE
handling of multiple transactions

### DIFF
--- a/lib/database/query.js
+++ b/lib/database/query.js
@@ -530,7 +530,7 @@ var Database = define(null, {
                             if (isFunction(arg1)) {
                                 ret = this.__enqueueTransaction(opts, arg1);
                             } else {
-                                if (this.supportsSavepoints && !isUndefinedOrNull(arg1.savepoint) && arg1.savepoint === true) {
+                                if (this.supportsSavepoints && arg1.savepoint === true) {
                                     //if we support save points there is a save point option then we
                                     //use __transaction again with the previous connection
                                     ret = this.__transaction(conn, arg1, arg2);


### PR DESCRIPTION
Hi, with regard to the issue [#104](https://github.com/C2FO/patio/issues/104) I've tried this change to put multiple transaction in queue rather than mixing them as it happens now.
I'm not sure if this might impact existing applications, but to be honest I think that mixing transaction is wrong in the first place (and as I've reported it may lead to errors) so I dare to say my approach should be the right one :)

Transactions are queued unless { savepoint: true } is specified. In this case everything should work as expected. I suppose that queuing might have a slight performance hit, but I think it's preferable to an unexpected result. I've thought about making them run in parallel, but I've currently no idea how to achieve that without possibily changing the API. Given the fact that it would also be quite a difficult task and I don't have enough time to devote to it right now, I'll leave it for a better time

I'm not an ORM expert, so feel free to review and improve my code :)
Thanks for your work with patio.
