### PR TITLE
v0.5.4

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+#0.5.4
+
+* Updated to `errback` the query promise when an error is caught.
+* Fixed issue with setting the `handleRowDescription` on a patio query.
+
 #0.5.3
 
 * Fixed issue with `logError` in transactions.

--- a/docs/History.html
+++ b/docs/History.html
@@ -362,6 +362,11 @@
 
 
 
+<h1>0.5.4</h1>
+<ul>
+<li>Updated to <code>errback</code> the query promise when an error is caught.</li>
+<li>Fixed issue with setting the <code>handleRowDescription</code> on a patio query.</li>
+</ul>
 <h1>0.5.3</h1>
 <ul>
 <li>Fixed issue with <code>logError</code> in transactions.</li>

--- a/lib/adapters/postgres.js
+++ b/lib/adapters/postgres.js
@@ -142,7 +142,10 @@ var Connection = define(null, {
                         return orig.apply(ret, arguments);
                     };
                 } catch (e) {
-                    getPatio().logError(e);
+                    ret = new PassThroughStream();
+                    setImmediate(function () {
+                        ret.emit("error", e);
+                    });
                 }
             } else {
                 ret = new PassThroughStream();
@@ -160,11 +163,10 @@ var Connection = define(null, {
                     this.connection.setMaxListeners(0);
                     var fields = [];
                     var q = this.connection.query(query, function (err, results) {
-                        q.handleRowDescription = orig;
                         if (err) {
-                            return ret.errback(err);
+                            ret.errback(err);
                         } else {
-                            return ret.callback(results.rows, fields);
+                            ret.callback(results.rows, fields);
                         }
                     });
                     var orig = q.handleRowDescription;
@@ -174,7 +176,7 @@ var Connection = define(null, {
                         return orig.apply(q, arguments);
                     };
                 } catch (e) {
-                    getPatio().logError(e);
+                    ret.errback(e);
                 }
             } else {
                 ret.errback(new Error("Connection already closed"));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "patio",
     "description": "Patio query engine and ORM",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "keywords": [
         "ORM",
         "object relation mapper",


### PR DESCRIPTION
- Updated to `errback` the query promise when an error is caught.
- Fixed issue with setting the `handleRowDescription` on a patio query.
