### PR TITLE
adding patio error emit on connection errors

### DIFF
--- a/lib/adapters/postgres.js
+++ b/lib/adapters/postgres.js
@@ -495,12 +495,15 @@ var DB = define(Database, {
             delete opts.query;
             var self = this, ret;
             var conn = new pg.Client(merge({}, opts, {typeCast: false}));
+
             conn.on("error", function (err) {
                 self.logWarn("Connection from " + self.uri + " errored removing from pool and reconnecting");
                 self.logWarn(err.stack);
                 ret.errored = true;
                 self.pool.removeConnection(ret);
+                getPatio().emit('error', err);
             });
+
             conn.on("end", function () {
                 if (!ret.closed) {
                     self.logWarn("Connection from " + self.uri + " unexpectedly ended");
@@ -508,8 +511,10 @@ var DB = define(Database, {
                     ret.closed = true;
                 }
             });
+
             conn.connect();
             ret = new Connection(conn);
+
             return ret;
         },
 
@@ -528,6 +533,7 @@ var DB = define(Database, {
             var timeout = opts.timeout || 30000,
                 ret,
                 connected = true, errored = false;
+
             var self = this;
             if (this.quoteIdentifiers) {
                 listeningChannel = listeningChannel.replace(/^"|"$/g, "");

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "patio",
     "description": "Patio query engine and ORM",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "keywords": [
         "ORM",
         "object relation mapper",
@@ -31,7 +31,7 @@
     "dependencies": {
         "comb": "~1.0.0",
         "comb-proxy": "~1.0.0",
-        "commander": ">=0.5.1",
+        "commander": "~2.9.0",
         "hive-cache": "0.0.3",
         "mysql": "2.10.0",
         "pg": "4.4.3",


### PR DESCRIPTION
This allows anyone to listen for the connection errors and handle them appropriately. For our case it will let us error out of the migration that just hangs if the DB isn't ready yet. 

- [x] @doug-martin 
- [ ] @aheuermann 