### PR TITLE
Adding defaultPrimaryKeyType and parseInt8 options

### DIFF
--- a/lib/adapters/postgres.js
+++ b/lib/adapters/postgres.js
@@ -1031,7 +1031,11 @@ var DB = define(Database, {
             },
 
             serialPrimaryKeyOptions: function () {
-                return {primaryKey: true, serial: true, type: "integer"};
+                return {
+                  primaryKey: true,
+                  serial: true,
+                  type: this.defaultPrimaryKeyType
+                };
             },
 
             supportsSavepoints: function () {

--- a/lib/adapters/postgres.js
+++ b/lib/adapters/postgres.js
@@ -44,7 +44,8 @@ var pg = require("pg"),
     stream = require("stream"),
     PassThroughStream = stream.PassThrough,
     pipeAll = require("../utils").pipeAll,
-    hashPick = comb.hash.pick;
+    hashPick = comb.hash.pick,
+    isSafeInteger = Number.isSafeInteger || require('is-safe-integer');
 
 var getPatio = function () {
     return patio || (patio = require("../index.js"));
@@ -77,6 +78,19 @@ var byteaParser = function (val) {
 };
 
 PgTypes.setTypeParser(17, "text", byteaParser);
+
+PgTypes.setTypeParser(20, 'text', function (val) {
+    if (!getPatio().parseInt8) {
+        return val;
+    }
+
+    var i = parseInt(val, 10);
+    if (!isSafeInteger(i)) {
+        throw new Error(format("The value '%s' cannot be represented by a javascript number.", val));
+    }
+    return i;
+});
+
 var timestampOrig = PgTypes.getTypeParser(1114, "text");
 //PgTypes.setTypeParser(25, "text", byteaParser);
 PgTypes.setTypeParser(1114, "text", function (val) {

--- a/lib/database/defaults.js
+++ b/lib/database/defaults.js
@@ -18,6 +18,7 @@ define(null, {
             this.__identifierInputMethod = isUndefined(opts.identifierInputMethod) ? isUndefined(statics.identifierInputMethod) ? this.identifierInputMethodDefault : statics.identifierInputMethod : opts.identifierInputMethod;
             this.__identifierOutputMethod = isUndefined(opts.identifierOutputMethod) ? isUndefined(statics.identifierOutputMethod) ? this.identifierOutputMethodDefault : statics.identifierOutputMethod : opts.identifierOutputMethod;
             this.__quoteIdentifiers = isUndefined(opts.quoteIdentifiers) ? isUndefinedOrNull(statics.quoteIdentifiers) ? this.quoteIdentifiersDefault : statics.quoteIdentifiers : opts.quoteIdentifiers;
+            this.__defaultPrimaryKeyType = isUndefined(opts.defaultPrimaryKeyType) ? (isUndefinedOrNull(statics.defaultPrimaryKeyType) ? this.defaultPrimaryKeyTypeDefault : statics.defaultPrimaryKeyType) : opts.defaultPrimaryKeyType;
         },
 
         getters:{
@@ -39,6 +40,17 @@ define(null, {
              */
             defaultSchemaDefault:function () {
                 return null;
+            },
+
+            /**
+             * Default type for primary/foreign keys when a type is not specified.
+             *
+             * @field
+             * @type String
+             * @default "integer"
+             */
+            defaultPrimaryKeyTypeDefault:function () {
+              return "integer";
             },
 
             /**
@@ -75,6 +87,17 @@ define(null, {
             },
 
             /**
+             * Default type for primary/foreign keys when a type is not specified.
+             *
+             * @field
+             * @type String
+             * @default "integer"
+             */
+            defaultPrimaryKeyType:function () {
+                return this.__defaultPrimaryKeyType;
+            },
+
+            /**
              * Default serial primary key options, used by the table creation
              * code.
              * @field
@@ -82,7 +105,11 @@ define(null, {
              * @default {primaryKey : true, type : "integer", autoIncrement : true}
              * */
             serialPrimaryKeyOptions:function () {
-                return {primaryKey:true, type:"integer", autoIncrement:true};
+                return {
+                  primaryKey:true,
+                  type: this.defaultPrimaryKeyType,
+                  autoIncrement:true
+                };
             },
 
             /**
@@ -178,6 +205,10 @@ define(null, {
 
             supportsSavepoints:function (supports) {
                 this.__supportsSavePoints = supports;
+            },
+
+            defaultPrimaryKeyType:function (type) {
+              this.__defaultPrimaryKeyType = type;
             }
         }
     },
@@ -189,6 +220,8 @@ define(null, {
         __identifierOutputMethod:undefined,
 
         __quoteIdentifiers:null,
+
+        __defaultPrimaryKeyType:undefined,
 
         getters:{
             /**@lends patio.Database*/
@@ -224,6 +257,16 @@ define(null, {
              */
             quoteIdentifiers:function () {
                 return this.__quoteIdentifiers;
+            },
+
+            /**
+             * The default type for primary keys if no type is specified.
+             * @ignore
+             * @type String
+             * Returns the default primary key type for schema migrations.
+             */
+            defaultPrimaryKeyType:function () {
+                return this.__defaultPrimaryKeyType;
             }
         },
 
@@ -238,6 +281,10 @@ define(null, {
 
             quoteIdentifiers:function (quoteIdentifiers) {
                 this.__quoteIdentifiers = quoteIdentifiers;
+            },
+
+            defaultPrimaryKeyType:function (type) {
+                this.__defaultPrimaryKeyType = type;
             }
         }
     }

--- a/lib/database/schemaGenerators.js
+++ b/lib/database/schemaGenerators.js
@@ -470,7 +470,7 @@ var AlterTableGenerator = define(null, {
             if (isArray(name)) {
                 return this.__addCompositeForeignKey(name, table, opts);
             } else {
-                return this.addColumn(name, "integer", merge({table:table}, opts));
+                return this.addColumn(name, this.db.defaultPrimaryKeyType, merge({table:table}, opts));
             }
         },
 
@@ -658,6 +658,3 @@ var AlterTableGenerator = define(null, {
         }
     }
 }).as(exports, "AlterTableGenerator");
-
-
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,6 +69,7 @@ var Patio = singleton([EventEmitter, Time], {
          *
          * patio.camelize = true;
          * patio.quoteIdentifiers=false;
+         * patio.defaultPrimaryKeyType = "integer" //"bigint"
          *
          * patio.createModel("my_table");
          *
@@ -624,6 +625,17 @@ var Patio = singleton([EventEmitter, Time], {
                 return LOGGER;
             },
 
+
+            /**
+             * The default type for primary keys if no type is specified.
+             * @ignore
+             * @type String
+             * Returns the default primary key type for schema migrations.
+             */
+            defaultPrimaryKeyType: function () {
+                return Database.defaultPrimaryKeyType;
+            },
+
             /**
              * Returns the default method used to transform identifiers sent to the database.
              * See (@link patio.Database.identifierInputMethod}
@@ -834,6 +846,22 @@ var Patio = singleton([EventEmitter, Time], {
                 this.identifierInputMethod = underscore ? "camelize" : "underscore";
                 this.__camelize = !underscore;
                 this.__underscore = underscore;
+            },
+
+            /**
+             * Set the default primary key type when not specified for all databases by default. By default,
+             * patio uses "integer".
+             *
+             * @ignoreCode
+             * @field
+             * @type String
+             *
+             * @example
+             *   //changing to bigint
+             *   patio.defaultPrimaryKeyType = "bigint"
+             * */
+            defaultPrimaryKeyType: function (value) {
+                Database.defaultPrimaryKeyType = value;
             }
         }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,6 +57,8 @@ var Patio = singleton([EventEmitter, Time], {
 
         __inImportOfModels: false,
 
+        __parseInt8: false,
+
 
         /**
          * A singleton class that acts as the entry point for all actions performed in patio.
@@ -69,6 +71,7 @@ var Patio = singleton([EventEmitter, Time], {
          *
          * patio.camelize = true;
          * patio.quoteIdentifiers=false;
+         * patio.parseInt8=false
          * patio.defaultPrimaryKeyType = "integer" //"bigint"
          *
          * patio.createModel("my_table");
@@ -677,6 +680,11 @@ var Patio = singleton([EventEmitter, Time], {
             /**@ignore*/
             underscore: function () {
                 return this.__underscore;
+            },
+
+            /**@ignore*/
+            parseInt8: function () {
+                return this.__parseInt8;
             }
 
         },
@@ -846,6 +854,21 @@ var Patio = singleton([EventEmitter, Time], {
                 this.identifierInputMethod = underscore ? "camelize" : "underscore";
                 this.__camelize = !underscore;
                 this.__underscore = underscore;
+            },
+
+            /**
+             * Sets whether bigint types should be parsed to a number. An error will be thrown if set and the number is
+             * set and the number is greater than 2^53 or less than -2^53.
+             *
+             * @ignoreCode
+             * @field
+             * @type Boolean
+             *
+             * @example
+             *   patio.parseInt8 = true
+             * */
+            parseInt8: function (value) {
+                this.__parseInt8 = value;
             },
 
             /**

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "comb-proxy": "~1.0.0",
         "commander": "~2.9.0",
         "hive-cache": "0.0.3",
+        "is-safe-integer": "1.0.1",
         "mysql": "2.10.0",
         "pg": "4.4.3",
         "pg-query-stream": "1.0.0",

--- a/test/adapters/postgres.test.js
+++ b/test/adapters/postgres.test.js
@@ -5,7 +5,8 @@ var it = require('it'),
     patio = require("../../lib"),
     sql = patio.SQL,
     comb = require("comb"),
-    config = require("../test.config.js");
+    config = require("../test.config.js"),
+    PgTypes = require('pg-types');
 
 if (process.env.PATIO_DB === "pg") {
     it.describe("patio.adapters.Postgres", function (it) {
@@ -543,6 +544,65 @@ if (process.env.PATIO_DB === "pg") {
                                 ]);
                             });
                     });
+            });
+
+            it.describe("parseInt8", function (it) {
+
+                it.beforeEach(function () {
+                    return db.forceCreateTable("posts", function () {
+                        this.postId("bigint");
+                    });
+                });
+
+                it.afterAll(function () {
+                    patio.parseInt8 = false;
+                    return db.dropTable("posts");
+                });
+
+                it.should("parse bigints on select if true", function () {
+                    var ds = db.from("posts");
+                    patio.parseInt8 = true;
+                    return ds.insert({postId: "9007199254740991"})
+                    .chain(function () {
+                        return ds.one();
+                    }).chain(function (post) {
+                        assert.strictEqual(post.postId, 9007199254740991);
+                    });
+                });
+
+                it.should("parse negative bigints as well", function () {
+                    var ds = db.from("posts");
+                    patio.parseInt8 = true;
+                    return ds.insert({postId: "-9007199254740991"})
+                        .chain(function () {
+                            return ds.one();
+                        }).chain(function (post) {
+                            assert.strictEqual(post.postId, -9007199254740991);
+                        });
+                });
+
+                it.should("not parse bigints if false", function () {
+                    var ds = db.from("posts");
+                    patio.parseInt8 = false;
+                    return ds.insert({postId: "9007199254740992"})
+                        .chain(function () {
+                            return ds.one();
+                        }).chain(function (post) {
+                            assert.strictEqual(post.postId, "9007199254740992");
+                        });
+                });
+
+                it.should("should throw if bigint is outside the range of max safe integer", function () {
+                    patio.parseInt8 = true;
+                    var bigIntParser = PgTypes.getTypeParser(20, 'text');
+                    assert.throws(function () {
+                        bigIntParser("9007199254740992");
+                    }, /The value \'9007199254740992\' cannot be represented by a javascript number\./);
+                    assert.throws(function () {
+                        bigIntParser("-9007199254740992");
+                    }, /The value \'\-9007199254740992\' cannot be represented by a javascript number\./);
+                });
+
             });
 
             it.should("support opclass specification", function () {

--- a/test/database/database.test.js
+++ b/test/database/database.test.js
@@ -155,6 +155,30 @@ it.describe("Database", function (it) {
             assert.equal(db.identifierOutputMethodDefault, "toLowerCase");
         });
 
+        it.describe("defaultPrimaryKeyType", function (it) {
+
+            it.should("has a defaultPrimaryKeyType of integer", function () {
+                var db = new Database();
+                assert.equal(db.defaultPrimaryKeyType, "integer");
+                assert.deepEqual(db.serialPrimaryKeyOptions, {
+                    primaryKey: true,
+                    type: "integer",
+                    autoIncrement:true
+                });
+            });
+
+            it.should("allow for overriding the option", function () {
+                var db = new Database({defaultPrimaryKeyType: "bigint"});
+                assert.equal(db.defaultPrimaryKeyType, "bigint");
+                assert.deepEqual(db.serialPrimaryKeyOptions, {
+                    primaryKey: true,
+                    type: "bigint",
+                    autoIncrement:true
+                });
+            });
+
+        });
+
         it.should("respect the identifierInputMethod option", function () {
             var db = new Database({identifierInputMethod: null});
             assert.isNull(db.identifierInputMethod);

--- a/test/patio.test.js
+++ b/test/patio.test.js
@@ -383,8 +383,14 @@ it.describe("patio", function (it) {
         assert.equal(patio.identifierInputMethod, "underscore");
     });
 
+    it.should("set defaultPrimaryKeyType values when using defaultPrimaryKeyType", function () {
+        patio.defaultPrimaryKeyType = "bigint";
+        assert.equal(patio.defaultPrimaryKeyType, "bigint");
+        assert.equal(Database.defaultPrimaryKeyType, "bigint");
+    });
 
     it.afterAll(function () {
+        patio.defaultPrimaryKeyType = null;
         patio.resetIdentifierMethods();
         return patio.disconnect();
     });


### PR DESCRIPTION
`defaultPrimaryKeyType` will only be used if the type is not specified.

`parseInt8` will parse the bigints and throw an error if not a "safe" integer.  Right now this kills the process since they are not caught. I submit two PRs which I think will fix this though (brianc/node-postgres#954 and brianc/node-pg-native#41).

Both changes are opt-in so no issues with backwards compatibility. Will also back-port this and create a  `0.9.7` release.

@doug-martin @dustinsmith1024 