### PR TITLE
adding eager loading on dataset and model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,6 @@ after_script:
 language: node_js
 node_js:
   - "4"
-  - "5"
+  - "5.6"
+  - "5.12"
+  - "stable"

--- a/lib/dataset/query.js
+++ b/lib/dataset/query.js
@@ -338,6 +338,102 @@ define({
             return this.mergeOptions({distinct: args});
         },
 
+        /*
+         * DB.from('company').filter({name: 'Amazon'})
+         *  .eager({
+         *      // company from parent query is passed in and usable in the eager query.
+         *      leader: (company) => DB.from('leader').filter({id: company.leaderId}).one()
+         *  })
+         *  // Load completely unrelated data.
+         *  .eager({org: () => DB.from('organization').one() })
+         *  .one()})
+         *
+         *  { id: 1,
+         *    name: 'Amazon.com',
+         *    leader: {
+         *      id: 1,
+         *      name: 'Jeff'
+         *    },
+         *    org: {
+         *      id: 1,
+         *      name: 'Google Inc.'
+         *    }
+         *  }
+         *
+         * Can do one to many loading for every item in the parent dataset.
+         * Be careful doing this because it can lead to lots of extra queries.
+         *
+         * DB.from('company').filter({state: 'IA'})
+         *  .eager({invoices: (company) => DB.from('invoices').filter({companyId: company.id}).one() })
+         *  .all()})
+         *
+         *  [
+         *   { id: 1,
+         *    name: 'Principal',
+         *    invoices: [
+         *      { id: 1, amount: 200},
+         *      { id: 2, amount: 300},
+         *    ]
+         *   },
+         *   { id: 2,
+         *    name: 'John Deere',
+         *    invoices: [
+         *      { id: 3, amount: 200},
+         *      { id: 4, amount: 300},
+         *    ]
+         *   }
+         *  ]
+         *
+         */
+        eager: function(includeDatasets, fromModel) {
+            var ds = this.mergeOptions({}),
+                originalRowCb = ds.rowCb;
+
+            if(!ds.__opts._eagerAssoc) {
+                ds.__opts._eagerAssoc = includeDatasets;
+                ds.rowCb = function (topLevelResults) {
+
+                    function toObject(thing) {
+                        if ('toObject' in thing) {
+                            return comb.when(thing.toObject());
+                        }
+                        return comb.when(thing);
+                    }
+
+                    var eagerResults = {},
+                        whens = [];
+
+                        if (!originalRowCb) {
+                            // pass through for when topLevelResults is already resolved
+                            originalRowCb = function(r){return r;};
+                        }
+
+                        return comb.when(originalRowCb(topLevelResults)).chain(function(maybeModel) {
+                            whens = Object.keys(ds.__opts._eagerAssoc).map(function(key) {
+                                return ds.__opts._eagerAssoc[key](maybeModel).chain(function(result) {
+                                    return toObject(result).chain(function(res) {
+                                        eagerResults[key] = res;
+                                        return result;
+                                    });
+                                });
+                            });
+
+                            return comb.when(whens).chain(function () {
+                                return toObject(maybeModel).chain(function(json) {
+                                    // merge associations on to main data
+                                    return Object.assign(json, eagerResults);
+                                });
+                            });
+
+                        });
+                };
+            }
+
+            return ds.mergeOptions({
+                _eagerAssoc: Object.assign(ds.__opts._eagerAssoc, includeDatasets)
+            });
+        },
+
         /**
          * Adds an EXCEPT clause using a second dataset object.
          * An EXCEPT compound dataset returns all rows in the current dataset
@@ -2327,7 +2423,7 @@ define({
         /**
          * Methods that return modified datasets
          */
-        QUERY_METHODS: ['addGraphAliases', "and", "distinct", "except", "exclude", "filter", "find", "is", "isNot",
+        QUERY_METHODS: ['addGraphAliases', "and", "distinct", "eager", "except", "exclude", "filter", "find", "is", "isNot",
             "eq", "neq", "lt", "lte", "gt", "gte", "forUpdate", "from", "fromSelf", "graph", "grep", "group",
             "groupAndCount", "groupBy", "having", "intersect", "invert", "limit", "lockStyle", "naked", "or", "order",
             "orderAppend", "orderBy", "orderMore", "orderPrepend", "qualify", "reverse",

--- a/lib/dataset/query.js
+++ b/lib/dataset/query.js
@@ -338,7 +338,13 @@ define({
             return this.mergeOptions({distinct: args});
         },
 
-        /*
+        /**
+         * Allows the loading of another query and combining them in one patio command.
+         * Queries can be related or completely unrelated.
+         * All data comes back as JSON NOT Patio models.
+         *
+         * @example
+         *
          * DB.from('company').filter({name: 'Amazon'})
          *  .eager({
          *      // company from parent query is passed in and usable in the eager query.
@@ -394,6 +400,14 @@ define({
                 ds.rowCb = function (topLevelResults) {
 
                     function toObject(thing) {
+                        if (!thing) {
+                            return comb.when(thing);
+                        }
+                        if (Array.isArray(thing)) {
+                            return comb.when(thing.map(function(item) {
+                                return toObject(item);
+                            }));
+                        }
                         if ('toObject' in thing) {
                             return comb.when(thing.toObject());
                         }

--- a/lib/model.js
+++ b/lib/model.js
@@ -347,61 +347,12 @@ var Model = define([QueryPlugin, Middleware], {
         },
 
         /**
-         * Convert this model to an object including any associations passed in.
-         *
-         * This will not handle recursive associations and is not useful when working with
-         * eager loaded models.
-         *
-         * @return {Object} the object version of this model.
-         **/
-        toObjectWithAssociations: function(associations) {
-            if (!associations) {
-                return this.toObject();
-            }
-
-            var includes = [],
-                modelInstance = this,
-                json = this.toObject(),
-                associationJson = {};
-
-            if (Array.isArray(associations)) {
-                includes = includes.concat(associations);
-            } else {
-                includes.push(associations);
-            }
-
-            var whens = (includes || []).map(function(associationName) {
-                return modelInstance[associationName].chain(function(association) {
-                    if (association) {
-                        if (!Array.isArray(association)) { // one-to-one
-                            associationJson[associationName] = association.toObject();
-                        } else {
-                            associationJson[associationName] = association.map(function(item) {
-                                return item.toObject();
-                            });
-                        }
-                    } else {
-                        associationJson[associationName] = null;
-                    }
-                });
-            });
-
-            return comb.when(whens).chain(function() {
-                return merge(json, associationJson);
-            });
-        },
-
-        /**
          * Convert this model to JSON, containing column, value pairs.
          *
          * @return {JSON} the JSON version of this model.
          **/
         toJSON: function () {
             return this.toObject();
-        },
-
-        toJSONWithAssociations: function(associations) {
-            return this.toObjectWithAssociations(associations);
         },
 
         /**

--- a/lib/model.js
+++ b/lib/model.js
@@ -347,12 +347,61 @@ var Model = define([QueryPlugin, Middleware], {
         },
 
         /**
+         * Convert this model to an object including any associations passed in.
+         *
+         * This will not handle recursive associations and is not useful when working with
+         * eager loaded models.
+         *
+         * @return {Object} the object version of this model.
+         **/
+        toObjectWithAssociations: function(associations) {
+            if (!associations) {
+                return this.toObject();
+            }
+
+            var includes = [],
+                modelInstance = this,
+                json = this.toObject(),
+                associationJson = {};
+
+            if (Array.isArray(associations)) {
+                includes = includes.concat(associations);
+            } else {
+                includes.push(associations);
+            }
+
+            var whens = (includes || []).map(function(associationName) {
+                return modelInstance[associationName].chain(function(association) {
+                    if (association) {
+                        if (!Array.isArray(association)) { // one-to-one
+                            associationJson[associationName] = association.toObject();
+                        } else {
+                            associationJson[associationName] = association.map(function(item) {
+                                return item.toObject();
+                            });
+                        }
+                    } else {
+                        associationJson[associationName] = null;
+                    }
+                });
+            });
+
+            return comb.when(whens).chain(function() {
+                return merge(json, associationJson);
+            });
+        },
+
+        /**
          * Convert this model to JSON, containing column, value pairs.
          *
          * @return {JSON} the JSON version of this model.
          **/
         toJSON: function () {
             return this.toObject();
+        },
+
+        toJSONWithAssociations: function(associations) {
+            return this.toObjectWithAssociations(associations);
         },
 
         /**
@@ -604,7 +653,6 @@ var Model = define([QueryPlugin, Middleware], {
                 this._setDb(this.__db);
             }
         },
-
 
         sync: function (cb) {
             var ret = new Promise();

--- a/lib/plugins/association.js
+++ b/lib/plugins/association.js
@@ -160,6 +160,8 @@ exports.AssociationPlugin = comb.define(null, {
         /*  Allows eager loading of an association. This does an extra SQL query for the association.
          *  It will load any association singular or plural.
          *
+         *  @example
+         *
          *  Person.eager('company').one()
          *  { id: 1,
          *    name: 'Obi-Wan',
@@ -187,10 +189,11 @@ exports.AssociationPlugin = comb.define(null, {
          *      id: 1,
          *      name: 'Jedi council'
          *    }
-         *  },
+         *  }]
+         *
          */
         eager: function(associations) {
-            var model = new this({}, true),
+            var model = new this(),
                 includes = [],
                 associationsObj = {};
 

--- a/lib/plugins/association.js
+++ b/lib/plugins/association.js
@@ -157,6 +157,61 @@ exports.AssociationPlugin = comb.define(null, {
             return this.associate(this.ONE_TO_MANY, name, options, filter);
         },
 
+        /*  Allows eager loading of an association. This does an extra SQL query for the association.
+         *  It will load any association singular or plural.
+         *
+         *  Person.eager('company').one()
+         *  { id: 1,
+         *    name: 'Obi-Wan',
+         *    company: {
+         *      id: 1,
+         *      name: 'Jedi council'
+         *    }
+         *  }
+         *
+         *  Person.eager(['emails', 'phones', 'company']).limit(2).all()
+         *  [{ id: 1,
+         *    name: 'Obi-Wan',
+         *    emails: ['obi@gmail.com', 'obi@jedi.com'],
+         *    phones: ['911', '888-991-0991'],
+         *    company: {
+         *      id: 1,
+         *      name: 'Jedi council'
+         *    }
+         *  },
+         *  { id: 2,
+         *    name: 'Luke',
+         *    emails: ['luke@gmail.com', 'luke@jedi.com'],
+         *    phones: ['911', '888-991-0992'],
+         *    company: {
+         *      id: 1,
+         *      name: 'Jedi council'
+         *    }
+         *  },
+         */
+        eager: function(associations) {
+            var model = new this({}, true),
+                includes = [],
+                associationsObj = {};
+
+            if (Array.isArray(associations)) {
+                includes = includes.concat(associations);
+            } else if(associations) {
+                includes.push(associations);
+            }
+
+            includes.forEach(function(association) {
+                associationsObj[association] = function(parent) {
+                    if (!parent[association]) {
+                        throw new Error("Association of " + association + " not found");
+                    }
+                    return parent[association];
+                };
+            });
+
+            return model.dataset.eager(associationsObj);
+        },
+
         /**
          * Creates a MANY_TO_ONE association.
          * See {@link patio.plugins.AssociationPlugin.oneToMany}.

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
         "patio": "./bin/patio"
     },
     "engines": {
-        "node": ">=4.0.0"
+        "node": ">=4.0.0 <6.0.0"
     }
 }

--- a/test/associations/staticEager.test.js
+++ b/test/associations/staticEager.test.js
@@ -1,0 +1,179 @@
+"use strict";
+
+var it = require('it'),
+    assert = require('assert'),
+    helper = require("../data/oneToOne.helper.js"),
+    patio = require("../../lib"),
+    comb = require("comb");
+
+var gender = ["M", "F"];
+
+it.describe("patio.Model static eager method", function (it) {
+    var Works, Employee, DB;
+    it.beforeAll(function () {
+        Works = patio.addModel("works");
+        Works.manyToOne("employee", {fetchType: Works.fetchType.LAZY});
+        Employee = patio.addModel("employee");
+        Employee.oneToMany("works", {fetchType: Employee.fetchType.LAZY});
+        DB = null;
+        return helper.createSchemaAndSync(true).chain(function(db){
+            DB = db;
+        });
+    });
+
+
+    it.should("have associations", function () {
+        assert.deepEqual(Employee.associations, ["works"]);
+        assert.deepEqual(Works.associations, ["employee"]);
+        var emp = new Employee();
+        var work = new Works();
+        assert.deepEqual(emp.associations, ["works"]);
+        assert.deepEqual(work.associations, ["employee"]);
+    });
+
+    it.describe("load associations", function (it) {
+
+        it.beforeEach(function () {
+            return comb
+                .when([
+                    Employee.remove(),
+                    Works.remove()
+                ])
+                .chain(function () {
+                    return new Employee({
+                        lastName: "last" + 1,
+                        firstName: "first" + 1,
+                        midInitial: "m",
+                        gender: gender[1 % 2],
+                        street: "Street " + 1,
+                        city: "City " + 1,
+                        works: [{
+                            companyName: "Google",
+                            salary: 100000
+                        },{
+                            companyName: "Alphabet",
+                            salary: 100000
+                        }]
+                    }).save();
+                }).chain(function () {
+                    return new Employee({
+                        lastName: "Skywalker",
+                        firstName: "Luke",
+                        midInitial: "m",
+                        gender: gender[1 % 2],
+                        street: "Street " + 1,
+                        city: "City " + 1,
+                        works: {
+                            companyName: "C2FO",
+                            salary: 200000
+                        }
+                    }).save();
+                });
+
+        });
+
+        it.should("when querying", function () {
+            return comb
+                .when([Employee.eager('works').one(), Works.eager('employee').one()])
+                .chain(function (res) {
+                    var emp = res[0], work = res[1];
+                    var empWorks = emp.works, worksEmp = work.employee;
+                    assert(emp.works[0].id, work.id);
+                    assert(work.employee.id, emp.id);
+                });
+        });
+
+        it.should("when querying with filtering", function () {
+            return Employee.eager('works').filter({lastName: "Skywalker"}).one()
+                .chain(function (emp) {
+                    assert(emp.id, emp.works[0].employeeId);
+                });
+        });
+
+        it.should("and load other eager queries", function () {
+            return Employee.eager('works').eager({
+                who: function(emp) {
+                    return Employee.findById(emp.id);
+                }
+            }).one().chain(function (emp) {
+                assert(emp.id, emp.works[0].employeeId);
+                assert(emp.id, emp.who.id);
+            }).chain(function() {
+                // run same queries back to back
+                // make sure eager is not being cached across model instances
+                return Employee.eager('works').eager({
+                    you: function(emp) {
+                        return Employee.findById(emp.id);
+                    }
+                }).one()
+                    .chain(function (emp) {
+                        assert(emp.id, emp.works[0].employeeId);
+                        assert.isUndefined(emp.who);
+                        assert(emp.id, emp.you.id);
+                    });
+            });
+        });
+
+    });
+
+    it.describe("dataset loading", function (it) {
+
+        it.beforeEach(function () {
+            return comb
+                .when([
+                    Employee.remove(),
+                    Works.remove()
+                ])
+                .chain(function () {
+                    return new Employee({
+                        lastName: "last" + 1,
+                        firstName: "first" + 1,
+                        midInitial: "m",
+                        gender: gender[1 % 2],
+                        street: "Street " + 1,
+                        city: "City " + 1,
+                        works: [{
+                            companyName: "Google",
+                            salary: 100000
+                        },{
+                            companyName: "Alphabet",
+                            salary: 100000
+                        }]
+                    }).save();
+                }).chain(function () {
+                    return new Employee({
+                        lastName: "Skywalker",
+                        firstName: "Luke",
+                        midInitial: "m",
+                        gender: gender[1 % 2],
+                        street: "Street " + 1,
+                        city: "City " + 1,
+                        works: {
+                            companyName: "C2FO",
+                            salary: 200000
+                        }
+                    }).save();
+                });
+
+        });
+
+        it.should("and load other eager queries", function () {
+            return DB.from('employee').filter({lastName: 'Skywalker'})
+                .eager({
+                    who: function(emp) {
+                        return DB.from('works').filter({employeeId: emp.id}).one();
+                    }
+                }).one()
+                    .chain(function (emp) {
+                        assert(emp.lastName, 'Skywalker');
+                        assert(emp.who.companyName, 'C2FO');
+                        assert(emp.id, emp.who.employeeId);
+                    });
+        });
+
+    });
+
+    it.afterAll(function () {
+        return helper.dropModels();
+    });
+});

--- a/test/data/oneToOne.helper.js
+++ b/test/data/oneToOne.helper.js
@@ -13,8 +13,8 @@ module.exports = {
 };
 
 function createSchemaAndSync(underscore) {
-    return createTables(underscore).chain(function(){
-        return patio.syncModels();
+    return createTables(underscore).chain(function(db){
+        return patio.syncModels().chain(db);
     });
 }
 
@@ -60,5 +60,5 @@ function createTables(underscore) {
                 this.salary("float", {size: [20, 8], allowNull: false});
                 this.foreignKey(underscore ? "employee_id" : "employeeId", "employee", {key: "id"});
             });
-        });
+        }).chain(DB);
 }

--- a/test/dataset/query.test.js
+++ b/test/dataset/query.test.js
@@ -1786,6 +1786,19 @@ it.describe("Dataset queries", function (it) {
         });
     });
 
+    it.describe("#eager", function (it) {
+        var db = new MockDatabase();
+        var dataset = db.from("test").eager({
+          test: function() {
+              return db.from('test2').one();
+          }
+        }).select("name");
+
+        it.should("not effect main SQL query", function () {
+            assert.equal(dataset.sql, 'SELECT name FROM test');
+        });
+    });
+
     it.describe("groupAndCount", function (it) {
         var ds = new Dataset().from("test");
 


### PR DESCRIPTION
~~This adds a `toObjectWithAssociation` method which embeds an association within the returned object. This is like eager loading, but you don't have to force your model to always eager load.~~

- [ ] @doug-martin 
- [ ] @aheuermann 

~~This was the simplest way I could find to do this. I wanted to put something on the dataset but it didn't really clean way to mix it into the API.~~

We ended up with the `.eager` method on Model and on dataset.  Look at the tests or comments for examples.

This will do an extra SQL query for your associations, but is much shorter than having to do it on your own and handle the promise resolving.

Let me know what you think. I will write some tests if we think its okay to add.