### PR TITLE
Do not typecast empty string to null for columns of type text 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,5 @@ after_script:
 
 language: node_js
 node_js:
-  - "4.2"
-  - "4.1"
-  - "5.1"
-  - "5.2"
-  - "5.3"
-  - "stable"
+  - "4"
+  - "5"

--- a/lib/database/query.js
+++ b/lib/database/query.js
@@ -175,13 +175,12 @@ var Database = define(null, {
             } else {
                 ret = new PassThroughStream({objectMode: true});
                 this._getConnection().chain(function (conn) {
+                    var queryStream = self.__executeStreamed(sql, opts, conn);
                     function fieldHandler(fields) {
                         ret.emit("fields", fields);
                         queryStream.removeListener("fields", fieldHandler);
                         queryStream = self = ret = null;
                     }
-
-                    var queryStream = self.__executeStreamed(sql, opts, conn);
                     queryStream.on("fields", fieldHandler);
                     pipeAll(queryStream, ret);
                 }, function (err) {
@@ -1096,5 +1095,3 @@ var Database = define(null, {
 
     }
 }).as(module);
-
-

--- a/lib/model.js
+++ b/lib/model.js
@@ -319,7 +319,7 @@ var Model = define([QueryPlugin, Middleware], {
             var colSchema, clazz = this._static;
             if (((fromDatabase && clazz.typecastOnLoad) || (!fromDatabase && clazz.typecastOnAssignment)) && !isUndefinedOrNull(this.schema) && !isUndefinedOrNull((colSchema = this.schema[column]))) {
                 var type = colSchema.type;
-                if (value === "" && clazz.typecastEmptyStringToNull === true && !isUndefinedOrNull(type) && ["string", "blob"].indexOf(type) === -1) {
+                if (value === "" && clazz.typecastEmptyStringToNull === true && !isUndefinedOrNull(type) && ["string", "blob", "text"].indexOf(type) === -1) {
                     value = null;
                 }
                 var raiseOnError = clazz.raiseOnTypecastError;

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -2786,7 +2786,7 @@ Json = define({
  * @memberOf patio.sql
  */
 function JsonArray(arr) {
-    if (!this instanceof JsonArray) {
+    if (!(this instanceof JsonArray)) {
         return new JsonArray(arr);
     }
     Array.call(this);

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "devDependencies": {
         "coveralls": "^2.11.2",
         "grunt": "^0.4.5",
-        "grunt-contrib-jshint": "^0.10.0",
+        "grunt-contrib-jshint": "^0.12.0",
         "grunt-coveralls": "^1.0.0",
         "grunt-exec": "^0.4.6",
         "grunt-it": "^1.0.0",

--- a/test/data/model.helper.js
+++ b/test/data/model.helper.js
@@ -44,6 +44,15 @@ function createTables(underscore) {
                 this[underscore ? "text_type" : "texttype"]("text");
                 this[underscore ? "blob_type" : "blobtype"]("blob");
             });
+        }).chain(function () {
+            return DB.forceDropTable("text_test").chain(function () {
+                return DB.forceCreateTable("text_test", function () {
+                    this.primaryKey("id");
+                    this["texttype"]("text");
+                    this["blobtype"]("blob");
+                    this["stringtype"]("string", {size: 20});
+                });
+            });
         });
 }
 
@@ -53,6 +62,9 @@ function dropModels() {
 
 function dropTableAndDisconnect() {
     return DB.dropTable("employee")
+        .chain(function () {
+             DB.dropTable("text_test");
+        })
         .chain(function () {
             return patio.disconnect();
         })

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -14,7 +14,7 @@ var gender = ["M", "F"];
 
 it.describe("patio.Model", function (it) {
 
-    var Employee;
+    var Employee, TextType;
     it.beforeAll(function () {
         Employee = patio.addModel("employee", {
             static: {
@@ -24,6 +24,7 @@ it.describe("patio.Model", function (it) {
                 }
             }
         });
+        TextType = patio.addModel("text_test", {});
         return helper.createSchemaAndSync();
     });
 
@@ -56,6 +57,28 @@ it.describe("patio.Model", function (it) {
         assert.isTrue(Buffer.isBuffer(emp.buffertype));
         assert.isString(emp.texttype);
         assert.isTrue(Buffer.isBuffer(emp.blobtype));
+    });
+
+    it.should("not type cast text types to null if empty", function () {
+        var text = new TextType({
+            texttype: ""
+        });
+        assert.strictEqual(text.texttype, "");
+    });
+
+    it.should("not type cast string types to null if empty", function () {
+        var text = new TextType({
+            stringtype: ""
+        });
+        assert.strictEqual(text.stringtype, "");
+    });
+
+    it.should("not type cast blob types to null if empty", function () {
+        var text = new TextType({
+            blobtype: ""
+        });
+        assert.isNotNull(text.blobtype);
+        assert.strictEqual(text.blobtype.toString(), "");
     });
 
 


### PR DESCRIPTION
- [x] @doug-martin 
- [x] @dustinsmith1024 

Currently it is not possible to save an empty string to a `text` type field unless you set `typecastEmptyStringToNull: false` (it defaults to `true`). In this case `string` is `varchar` so I am assuming `text` was just left out. Let me know what you think.