### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/History.md
+++ b/History.md
@@ -58,41 +58,41 @@
 
 * Removed `\` escaping in postgres adapter as it is not the default in versions >= 9.1
 
-#0.7.0
+# 0.7.0
 
 * Fix for issue [#121](https://github.com/C2FO/patio/issues/121) added the table name to the error thrown.
 * Merged [#120](https://github.com/C2FO/patio/pull/120) this allows tables registered with DB to be looked up properly.
    * This will break any `getModel` call where a table with the same name is added twice.
 * Added documentation about running tests.
 
-#0.6.1
+# 0.6.1
 
 * Added details for logging if the err.detail exists.
 * Changed streaming highWaterMark
 
-#0.6.0
+# 0.6.0
 
 * Fixed issue where grouped expressions with arrays and hashes as items, the expressions generated from the hashes are anded and each array item is ORed properly [#115](https://github.com/C2FO/patio/pull/115)
 
-#0.5.4
+# 0.5.4
 
 * Updated to `errback` the query promise when an error is caught.
 * Fixed issue with setting the `handleRowDescription` on a patio query.
 
-#0.5.3
+# 0.5.3
 
 * Fixed issue with `logError` in transactions.
 
-#0.5.2
+# 0.5.2
 
 * Fixed issue with `streams` in transactions.
 
-#0.5.1
+# 0.5.1
 
 * Update `comb` to `v0.3.0`
 * Fixed issues with `savepoints` and update transaction to conform with docs. [#110](https://github.com/C2FO/patio/pull/110)
 
-#0.5.0
+# 0.5.0
 
 * Added a new `stream` method to allow the streaming of large datasets from the database.
 * Added a new `isolate` option to `db.transaction` to ensure that the transaction is not nested inside of a concurrently running transaction.
@@ -133,7 +133,7 @@
 
 * Fixed constraint creation to accept a function when creating or altering constraints.
 
-#v0.2.15
+# v0.2.15
 
 * Updated patio migrate to use an exit code of `1` if the migration fails. [#92](https://github.com/C2FO/patio/issues/92)
 * Fixed the use of hashes in `andGrouped*` methods.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 [![NPM](https://nodei.co/npm/patio.png?downloads=true)](https://nodei.co/npm/patio/)
 
-#[Patio](http://c2fo.github.com/patio)
+# [Patio](http://c2fo.github.com/patio)
 
 Patio is a <a href="http://sequel.rubyforge.org/" target="patioapi">Sequel</a> inspired query engine.
 
-###Installation
+### Installation
 To install patio run
 
 `npm install comb patio`
@@ -16,7 +16,7 @@ If you want to use the patio executable for migrations
 
 `npm install -g patio`
 
-###Running Tests
+### Running Tests
 
 To run the tests 
 
@@ -36,13 +36,13 @@ To run just the mysql tests
 make test-mysql
 ```
 
-###Why Use Patio?
+### Why Use Patio?
                                                                                                                                                              
 Patio is different because it allows the developers to choose the level of abtraction they are comfortable with.                                             
 
 If you want to use the [ORM](http://c2fo.github.com/patio/models.html) functionality you can. If you don't you can just use the [Database](http://c2fo.github.com/patio/DDL.html) and [Datasets](http://c2fo.github.com/patio/querying.html) as a querying API, and if you need to you can [write plain SQL](http://c2fo.github.com/patio/patio_Database.html#run)
 
-###Concepts
+### Concepts
 
 1. Model definitions are defined by the tables in the database.
 
@@ -86,7 +86,7 @@ If you want to use the [ORM](http://c2fo.github.com/patio/models.html) functiona
     ```
 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
-###Getting Started
+### Getting Started
 
 All the code for this example can be found [here](https://github.com/C2FO/patio/tree/master/example/readme-example)
 
@@ -213,7 +213,7 @@ All the code for this example can be found [here](https://github.com/C2FO/patio/
         });
     ```
 
-###Guides
+### Guides
 
 * [Migrations](http://c2fo.github.com/patio/migrations.html)
 * [Models](http://c2fo.github.com/patio/models.html)
@@ -225,7 +225,7 @@ All the code for this example can be found [here](https://github.com/C2FO/patio/
 * [DDL](http://c2fo.github.com/patio/DDL.html)
 * [Logging](http://c2fo.github.com/patio/logging.html)
 
-###Features
+### Features
 
 * Comprehensive documentation with examples.
 * &gt; 80% test coverage

--- a/docs-md/DDL.md
+++ b/docs-md/DDL.md
@@ -1,7 +1,7 @@
-#DDL
+# DDL
 
 
-##[createTable](./patio_Database.html#createTable)
+## [createTable](./patio_Database.html#createTable)
 
 
 Patio supports the creation to tables through an instance of [patio.Database](./patio_Database.html#createTable). The [createTable](./patio_Database.html#createTable) method is used by passing it a name of the table to create and a function which performs the actions to create `column`s, `indexe`s, `foreignKey`s, `constraint`s, and `primaryKey`s.
@@ -57,7 +57,7 @@ When creating a table there are a number of methods that can be invoked to creat
 
 The most commonly used methods are:
 
-###[column](./patio_SchemaGenerator.html#column)
+### [column](./patio_SchemaGenerator.html#column)
 
 Add a column to the DDL.  
 
@@ -94,7 +94,7 @@ DB.createTable("test", function(){
 });
 ```
 
-###[primaryKey](./patio_SchemaGenerator.html#primaryKey)
+### [primaryKey](./patio_SchemaGenerator.html#primaryKey)
 
 Adds an auto-incrementing primary key column or a primary key constraint to the DDL
 
@@ -128,7 +128,7 @@ DB.createTable("test", function(){
 });
 ```
 
-###[foreignKey](./patio_SchemaGenerator.html#foreignKey)
+### [foreignKey](./patio_SchemaGenerator.html#foreignKey)
 
 Add a foreign key constraint to the DDL.
 
@@ -161,7 +161,7 @@ DB.createTable("flight_leg", function () {
 });
 ```
 
-###[index](./patio_SchemaGenerator.html#index)
+### [index](./patio_SchemaGenerator.html#index)
 
 Adds an index to the the DDL. For single columns, calling index is the same as using the `index` option when creating the column:
 
@@ -194,7 +194,7 @@ DB.createTable("test", function(){
 });
 ```
 
-###[unique](./patio_SchemaGenerator.html#unique)
+### [unique](./patio_SchemaGenerator.html#unique)
 The unique method creates a unique constraint on the table. A unique constraint generally operates identically to a unique index.
 
 ```
@@ -227,7 +227,7 @@ DB.createTable("test", function(){
 
 ```
 
-###[constraint](./patio_SchemaGenerator.html#constraint)
+### [constraint](./patio_SchemaGenerator.html#constraint)
 
 creates a named table constraint:
 
@@ -252,7 +252,7 @@ DB.createTable("test", function(){
 });
 ```
 
-###[check](./patio_SchemaGenerator.html#check)
+### [check](./patio_SchemaGenerator.html#check)
 
 Operates just like [constraint](./patio_SchemaGenerator.html#constraint), except that it doesn't take a name and it creates an unnamed constraint.
 
@@ -266,7 +266,7 @@ DB.createTable("test", function(){
 });
 ```
 
-##[alterTable](./patio_Database.html#alterTable)
+## [alterTable](./patio_Database.html#alterTable)
 
 [alterTable](./patio_Database.html#alterTable) is used to alter a tables definition. It is used just like [createTable](./patio_Database.html#createTable) where you use a function to alter the table's definition. For a full reference see [patio.AlterTableGenerator](./patio_AlterTableGenerator.html).
 
@@ -282,7 +282,7 @@ DB.createTable("test", function(){
 });
 ```
 
-###[addColumn](./patio_AlterTableGenerator.html#addColumn)
+### [addColumn](./patio_AlterTableGenerator.html#addColumn)
 
 This method adds a column to the table. This method is similar to `createTable`'s column method where the first parameter is the column and the second parameter is the data type and third parameter an optional options hash
 
@@ -294,7 +294,7 @@ This method adds a column to the table. This method is similar to `createTable`'
  });
 ```
 
-###[dropColumn](./patio_AlterTableGenerator.html#dropColumn)
+### [dropColumn](./patio_AlterTableGenerator.html#dropColumn)
 
 This method removes a column from the table definition.
 
@@ -306,7 +306,7 @@ DB.alterTable("test", function(){
  });
 ```
 
-###[renameColumn](./patio_AlterTableGenerator.html#renameColumn)
+### [renameColumn](./patio_AlterTableGenerator.html#renameColumn)
 
 This method renames a column.
 
@@ -318,7 +318,7 @@ DB.alterTable("test", function(){
  });
 ```
 
-###[addPrimaryKey](./patio_AlterTableGenerator.html#addPrimaryKey)
+### [addPrimaryKey](./patio_AlterTableGenerator.html#addPrimaryKey)
  
 This method is used to add a primaryKey to a table incase you forgot to include a primaryKey when creating the table.
 
@@ -344,7 +344,7 @@ DB.alterTable("test", function(){
 });
 ```
 
-###[addForeignKey](./patio_AlterTableGenerator.html#addForeignKey)
+### [addForeignKey](./patio_AlterTableGenerator.html#addForeignKey)
 
 This method is used to add a foreign key to a table. Like when using `addPrimaryKey` if you pass a string as the first argument then a column will be created.
 
@@ -372,7 +372,7 @@ DB.alterTable("test", function(){
 });
 ```
 
-###[addIndex](./patio_AlterTableGenerator.html#addIndex)
+### [addIndex](./patio_AlterTableGenerator.html#addIndex)
 
 Just like `createTable`'s index method.
 
@@ -390,7 +390,7 @@ DB.alterTable("test", function(){
 });
 ```
 
-###[dropIndex](./patio_AlterTableGenerator.html#dropIndex)
+### [dropIndex](./patio_AlterTableGenerator.html#dropIndex)
 
 Drops an index from a table.
 
@@ -408,7 +408,7 @@ DB.alterTable("test", function(){
 });
 ```
 
-###[addConstraint](./patio_AlterTableGenerator.html#addConstraint)
+### [addConstraint](./patio_AlterTableGenerator.html#addConstraint)
 
 Adds a named constraint to a table. Just like `createTable`'s constraint method.
 
@@ -423,7 +423,7 @@ DB.alterTable("test", function(){
 **Note:** there is not a method to add an unnamed constraint when altering a table.
 
 
-###[addUniqueConstraint](./patio_AlterTableGenerator.html#addUniqueConstraint)
+### [addUniqueConstraint](./patio_AlterTableGenerator.html#addUniqueConstraint)
 
 Adds a unique constraint to a table. Just like `createTable`'s unique method.
 
@@ -433,7 +433,7 @@ DB.alterTable("test", function(){
 });
 ```
 
-###[dropConstraint](./patio_AlterTableGenerator.html#dropConstraint)
+### [dropConstraint](./patio_AlterTableGenerator.html#dropConstraint)
 
 Drops a named constraint from a table.
 
@@ -453,7 +453,7 @@ DB.alterTable("albums", function(){
 });
 ```
 
-###[setColumnDefault](./patio_AlterTableGenerator.html#setColumnDefault)
+### [setColumnDefault](./patio_AlterTableGenerator.html#setColumnDefault)
 
 Sets a columns default value.
 
@@ -464,7 +464,7 @@ DB.alterTable("test", function(){
 });
 ```
 
-###[setColumnType](./patio_AlterTableGenerator.html#setColumnType)
+### [setColumnType](./patio_AlterTableGenerator.html#setColumnType)
 
 Sets the columns type.
 
@@ -474,7 +474,7 @@ DB.alterTable("test", function(){
 });
 ```
 
-###[setAllowNull](./patio_AlterTableGenerator.html#setAllowNull)
+### [setAllowNull](./patio_AlterTableGenerator.html#setAllowNull)
 
 Changes the NULL/NOT NULL modifier of a column.
 
@@ -485,7 +485,7 @@ DB.alterTable("test", function(){
 });
 ```
 
-##[patio.Database](./patio_Database.html) modification methods
+## [patio.Database](./patio_Database.html) modification methods
 
 [patio.Database](./patio_Database.html) has methods that act as shortcuts to an [alterTable](./patio_Database.html#alterTable) call these methods include
 
@@ -508,9 +508,9 @@ DB.alterTable("test", function(){
 DB.addColumn("test", "num", "integer");
 ```
 
-##Tables
+## Tables
 
-###[dropTable](./patio_Database.html#dropTable)
+### [dropTable](./patio_Database.html#dropTable)
 
 Can drop either a single table or multiple tables at a time.
 
@@ -522,7 +522,7 @@ DB.dropTable("leg_instance", "flight_leg", "flight", "airplane", "can_land", "ai
 DB.dropTable("leg_instance");
 ```
 
-###[renameTable](./patio_Database.html#renameTable)
+### [renameTable](./patio_Database.html#renameTable)
 
 Renames an existing table.
 
@@ -530,7 +530,7 @@ Renames an existing table.
 DB.renameTable("test", "test_old");
 ```
 
-###[forceCreateTable](./patio_Database.html#forceCreateTable)
+### [forceCreateTable](./patio_Database.html#forceCreateTable)
 
 Forcibly creates a table, attempting to drop it unconditionally (and catching any errors), then creating it. **Note:** This should not be used within a transaction as it could cause the transaction to fail.
 
@@ -543,7 +543,7 @@ DB.forceCreateTable("test", function(){
 });
 ```
 
-###[createTableUnlessExists](./patio_Database.html#createTableUnlessExists)
+### [createTableUnlessExists](./patio_Database.html#createTableUnlessExists)
 
 Creates the table unless the table already exists.
 
@@ -556,9 +556,9 @@ DB.createTableUnlessExists("test", function(){
 });
 ```
 
-##Views
+## Views
 
-###[createView](./patio_Database.html#createView)
+### [createView](./patio_Database.html#createView)
 
 Creates a view based on a dataset or an SQL string:
 
@@ -570,7 +570,7 @@ DB.createView("cheapItems", "SELECT * FROM items WHERE price < 100");
 DB.createView("miscItems", DB[:items].filter({category : 'misc'}));
 ```
 
-###[createOrReplaceView](./patio_Database.html#createOrReplaceView)
+### [createOrReplaceView](./patio_Database.html#createOrReplaceView)
 
 Same as create view but replaces the view if it already exists.
 
@@ -582,7 +582,7 @@ DB.createOrReplaceView("cheapItems", "SELECT * FROM items WHERE price < 100");
 DB.createOrReplaceView("miscItems", DB[:items].filter({category : 'misc'}));
 ```
 
-###[dropView](./patio_Database.html#dropView)
+### [dropView](./patio_Database.html#dropView)
 
 Similar to `dropTable` but instead of a table it drops a view.
 

--- a/docs-md/associations.md
+++ b/docs-md/associations.md
@@ -1,8 +1,8 @@
 
-#Associations
+# Associations
 
 
-##Supported Association types
+## Supported Association types
 
 
 * **oneToMany** : Foreign key in associated model's table points to this model's primary key. Each current model object can be associated with more than one associated model objects. Each associated model object can be associated with only one current model object.
@@ -14,7 +14,7 @@
 * **manyToMany** : A join table is used that has a foreign key that points to this model's primary key and a foreign key that points to the associated model's primary key. Each current model object can be associated with many associated model objects, and each associated model object can be associated with many current model objects.</li>
 
 
-##Options
+## Options
 
 
 
@@ -93,7 +93,7 @@ patio.addModel("class").manyToMany("students", {readOnly : true});
 patio.addModel("class").manyToMany("students", {select : ["firstName", "lastName"]});
 ```
 
-###ManyToOne additional options:
+### ManyToOne additional options:
 
 * **key** : foreignKey in current model's table that references associated model's primary key. Defaults to : "{tableName}Id". Can use an array of strings for a composite key association.
 
@@ -143,7 +143,7 @@ patio.addModel("stepFather").oneToMany("children", {key : "stepFatherKey", prima
 patio.addModel("child").manyToOne("stepFather", {key : "stepFatherKey", primaryKey : "name"});
 ```
 
-###OneToMany and OneToOne additional options:
+### OneToMany and OneToOne additional options:
 
 * **key** : foreign key in associated model's table that references current model's primary key, as a symbol. Defaults to "{thisTableName}Id". Can use an array of columns for a composite key association. **For examples see the ManyToOne examples above**.
 
@@ -151,7 +151,7 @@ patio.addModel("child").manyToOne("stepFather", {key : "stepFatherKey", primaryK
 * primaryKey : column in the current table that **key** option references. Defaults to primary key of the current table. Can use an array of strings for a composite key association. **For examples see the ManyToOne examples above**.
         
 
-###ManyToMany additional options:
+### ManyToMany additional options:
 
 * **joinTable** : name of table that includes the foreign keys to both the current model and the associated model. Defaults to the name of current model and name of associated model, pluralized, sorted, and camelized.
 
@@ -225,7 +225,7 @@ patio.addModel("student")
 ```
 
 
-##Filter Block
+## Filter Block
 You may also pass a function to the association to perform additional filtering on the dataset.
 
 
@@ -254,7 +254,7 @@ patio.addModel("student")
     });
 ```
 
-##[oneToMany](./patio_Model.html#.oneToMany)
+## [oneToMany](./patio_Model.html#.oneToMany)
 
 One of the most common forms of associations. One to Many is the inverse of Many to one. One to Many often describes a parent child relationship, where the One To Many [Model](./patio_Model.html) is the parent, and the many to one model is the child.
 
@@ -357,7 +357,7 @@ When working with eager associations the eagerly loaded association will be fetc
 
 
 
-###[oneToOne](./patio_Model.html#.oneToOne)
+### [oneToOne](./patio_Model.html#.oneToOne)
 
 Similar to `ONE_TO_MANY`  in terms of foreign keys, but only one object is associated to the current object through the association. The methods created are similar to `MANY_TO_ONE` , except that the `ONE_TO_ONE`  setter method saves the passed object.
 
@@ -517,7 +517,7 @@ Capital.order("name").forEach(function(capital){
 lazy loaded. To change this set the **fetchType** to **EAGER**.
 
 
-###[manyToMany](./patio_Model.html#.manyToMany)
+### [manyToMany](./patio_Model.html#.manyToMany)
 
 A join table is used that has a foreign key that points to this model's primary key and a foreign key that
 points to the associated model's primary key. Each current model object can be associated with many associated

--- a/docs-md/connecting.md
+++ b/docs-md/connecting.md
@@ -1,13 +1,13 @@
 
-#Connecting to a database
+# Connecting to a database
 
 
-##[patio.createConnection](./patio.html#createConnection)
+## [patio.createConnection](./patio.html#createConnection)
 
 
 When using [patio.createConnection](./patio.html#createConnection) to connect a database there are two types of parameters you can use.
 
-###Connetion URI
+### Connetion URI
 
 This is a well formed URI that will be used to connect to the database.
 
@@ -33,7 +33,7 @@ This is a well formed URI that will be used to connect to the database.
 var DB = patio.createConnection("mysql://test:testpass@localhost:3306/test?maxConnections=1&minConnections=10");    
 ```
 
-###Connection Object
+### Connection Object
 
 This is an object to used to connect.
 
@@ -76,7 +76,7 @@ var DB = patio.createConnection({
     // 1 connection by default and a max of 10
 ```
 
-##Disconnecting
+## Disconnecting
 
 To disconnect from a database you can use:
 

--- a/docs-md/logging.md
+++ b/docs-md/logging.md
@@ -1,5 +1,5 @@
 
-#Logging
+# Logging
 
 Patio uses the [comb.logging](http://pollenware.github.com/comb/symbols/comb.logging.Logger.html) framework for all logging. To set up logging there are two scenarios.
 

--- a/docs-md/migrations.md
+++ b/docs-md/migrations.md
@@ -1,11 +1,11 @@
 
         
-#Migrations
+# Migrations
 
 
 Migrates the database using migration files found in the supplied directory.
 
-##Integer Migrations
+## Integer Migrations
 
 Integer migrations are the simpler of the two migrations but are less flexible than timestamp based migrations. In order for patio to determine which versions the file must have the naming format "{versionnumber}.someFileName.js" where versionNumber is a integer **starting at 0** representing the version number.
 
@@ -34,7 +34,7 @@ In order to easily identify where certain schema alterations have taken place it
 ```
 
 
-##Timestamp Migrations
+## Timestamp Migrations
 
 Timestamp migrations are the more complex of the two migrations but offer greater flexibility especially with development teams. This is because Timestamp migrations:
 
@@ -76,24 +76,24 @@ In order to easily identify where certain schema alterations have taken place it
 
 
 
-##Mixed Migrations
+## Mixed Migrations
 
 If you start with IntegerBased migrations and decide to transition to Timestamp migrations the patio will attempt to merge the two migrations. It does this by ordering the files based off of the versionNumber order. So Integerbase migrations will come first. If the version number in any file with a version number lower than or equal to the current verion will be inserted into the schema_migration table and and file with a version greater will be applied up the the supplied target, or greatest version number and will be inserted into the database.
 
-##Migration Files
+## Migration Files
 
 Migration files are files with an up and down method.
                 
-###exports.up
+### exports.up
 
 The up function is called when applying the migration. The up function typically contains create and alter table statements. See [DDL](./DDL.html) for more examples and operations that are available.
 
 
-###exports.down
+### exports.down
 
 The down function is called when rolling back the migration. The down function typically contains drop and alter table statements. See [DDL](./DDL.html) for more examples and operations that are available.
 
-##Example migration file
+## Example migration file
 
 ```
 var comb = require("comb"),
@@ -187,12 +187,12 @@ exports.down = function(db) {
 
 First we wait for both the rename and createTable action to complete, and then we perform some database actions and finally resolve.
 
-##Running migrations
+## Running migrations
 
 
 In order to run a migraton there are two options:
 
-###[patio.migrate](./patio.html#migrate)
+### [patio.migrate](./patio.html#migrate)
 
 **Available options**
                      
@@ -211,7 +211,7 @@ In order to run a migraton there are two options:
   }, errorHandler);
 ```
 
-###Patio Executable
+### Patio Executable
 
 patio comes with an executable script that can be used to run the migrations
 

--- a/docs-md/model-inheritance.md
+++ b/docs-md/model-inheritance.md
@@ -1,9 +1,9 @@
 
-#Model Inheritance
+# Model Inheritance
 
 
 
-##[Class Table Inheritance](http://www.martinfowler.com/eaaCatalog/classTableInheritance.html)
+## [Class Table Inheritance](http://www.martinfowler.com/eaaCatalog/classTableInheritance.html)
 
 Consider the following table model.
 

--- a/docs-md/models.md
+++ b/docs-md/models.md
@@ -1,4 +1,4 @@
-#Models
+# Models
 
 Models are an optional feature in patio that can be extended to encapsulate, query, and associate tables.
 
@@ -69,7 +69,7 @@ The flow for the above example is as follows:
    * disconnect from the database
  * The final output should be "BobYukon's id is 1".
 
-##Options
+## Options
 
 Models some options that allow for the customization of the way a model be haves when interacting
 with the database.
@@ -200,7 +200,7 @@ patio.addModel("user", {
 });
 ```                    
 
-##Creating a model
+## Creating a model
 To create a Model class to use within your code you use the [patio.addModel](.patio.html#addModel) method. 
 
 ```
@@ -253,9 +253,9 @@ patio.syncModels().chain(function(User1,User2){
 });
 ```
 
-##Custom setters and getters
+## Custom setters and getters
 
-###Setters
+### Setters
 
 patio creates setters and getters for each column in the database if you want alter the value of a particular property before its set on the model you can use a custom setter.
 
@@ -284,7 +284,7 @@ patio.syncModels().chain(function(User){
 });
 ```
 
-###Getters
+### Getters
 
 Custom getters can be used to change values returned from the database but not alter the value when persisting. 
 
@@ -341,7 +341,7 @@ patio.syncModels().chain(function(User){
 ```
 
 
-##Model hooks
+## Model hooks
 
 Each model has the following hooks
 

--- a/docs-md/plugins.md
+++ b/docs-md/plugins.md
@@ -1,10 +1,10 @@
-#Plugins
+# Plugins
 
 One of the powerful features of the `patio` [Model](./models.html) api is plugins. Plugins allow developers to easily extend models to do extra functionality.
 
-##Built In Plugins
+## Built In Plugins
 
-###[patio.plugins.TimeStampPlugin](./patio_plugins_TimeStampPlugin.html)
+### [patio.plugins.TimeStampPlugin](./patio_plugins_TimeStampPlugin.html)
 
 This plugin adds timestamp functionality to models. (i.e updated and created).
 
@@ -106,11 +106,11 @@ var MyModel = patio.addModel("testTable", {
 });                                                                                                               
 ```
 
-###[patio.plugins.ClassTableInhertiance](./patio_plugins_ClassTableInhertiance.html)
+### [patio.plugins.ClassTableInhertiance](./patio_plugins_ClassTableInhertiance.html)
 
 See [inheritance](./model-inheritance.html) page.
 
-###[patio.plugins.ColumnMapper](./patio_plugins_ColumnMapper.html)
+### [patio.plugins.ColumnMapper](./patio_plugins_ColumnMapper.html)
 
 Add a mapped column from another table. This is useful if there columns on                                                               
 another table but you do not want to load the association every time.                                                                    
@@ -171,7 +171,7 @@ employee.update(null, {reloadMapped : false});
 * `column` : The column on the remote table that should be used. This is useful if you want to mapped column named something differently. Defaults to `null`                               
 as the local copy.  
 
-###[patio.plugins.ValidatorPlugin](./patio_plugins_ValidatorPlugin.html)
+### [patio.plugins.ValidatorPlugin](./patio_plugins_ValidatorPlugin.html)
 
 A validation plugin for patio models. This plugin adds a `validate` method to each [Model](./patio_Model.html)
 class that adds it as a plugin. This plugin does not include most typecast checks as `patio` already checks
@@ -290,12 +290,12 @@ The options include
                                                                                                                                                            
                                                                                                                                                                                                                           
 
-##Writing your own plugins
+## Writing your own plugins
 
 Writing your own custom plugin easy!
 
 
-###Example Express plugin
+### Example Express plugin
 
 The following is a simple express plugin to expose routes for models.
 
@@ -484,7 +484,7 @@ var app = express.createServer();
 Flight.route(app);
 ```
 
-###Example Logging Plugin
+### Example Logging Plugin
 
 The folowing plugin adds a logger to each model that uses the plugin. And adds convenience methods for logging.
 

--- a/docs-md/querying.md
+++ b/docs-md/querying.md
@@ -1,7 +1,7 @@
-#Querying
+# Querying
 
 
-##Reading objects
+## Reading objects
 
 patio provides a few separate methods for retrieving objects from the database. The underlying
 method is [forEach](./patio_Dataset.html#forEach), which interates each row as the [patio.Database](./patio_Database.html) provides it. However, while [forEach](./patio_Dataset.html#forEach) can and often is used directly, in many cases there is a more convenient retrieval method you can use.
@@ -14,7 +14,7 @@ var errorHandler = function(err){
 }
 ```
 
-##Getting a dataset
+## Getting a dataset
 
 To get a dataset use the [DB.from](./patio_Database.html#from) method.
 
@@ -23,9 +23,9 @@ var DB = patio.connect(<CONNECTION_URI>)
 var User = DB.from("user");
 ```
 
-##Retrieving a Single Object
+## Retrieving a Single Object
 
-###Using a Primary Key
+### Using a Primary Key
 
 The [findById](./patio_Model.html#.findById) is the easiest method to use to find a model instance by its primary key value:
 
@@ -38,7 +38,7 @@ User.findById(1).chain(function(user){
 
 **Note** If there is no record with the given primary key, the promise will resolve with null.
          
-###[first](./patio_Dataset.html#first)
+### [first](./patio_Dataset.html#first)
 
 If you just want the first record in the dataset use [first](./patio_Dataset.html#first).
 
@@ -60,7 +60,7 @@ User.first(sql.name.like('B%')).chain(function(user){
 }, errorHandler);
 ```
                
-###[last](./patio_Dataset.html#last)
+### [last](./patio_Dataset.html#last)
                         
 If you want the last record in the dataset use [last](./patio_Dataset.html#last).
 
@@ -73,7 +73,7 @@ If you want the last record in the dataset use [last](./patio_Dataset.html#last)
      // SELECT * FROM user ORDER BY name DESC LIMIT 1
 }, errorHandler);
 ```
-###[get](./patio_Dataset.html#get)
+### [get](./patio_Dataset.html#get)
       
 Sometimes, instead of wanting an entire row, you only want the value of a specific column. For this [get](./patio_Dataset.html#get) is the method you want:
 
@@ -83,9 +83,9 @@ User.get("name").chain(function(name){
 }, errorHandler);
 ```
 
-##Reading Multiple Records
+## Reading Multiple Records
 
-###[stream](./patio_Dataset.html#stream)
+### [stream](./patio_Dataset.html#stream)
 
 This method allows you to stream records from a database. This is useful if you have too much data to process in memory.
 
@@ -117,7 +117,7 @@ var stream = User
 ```
 
 
-###[all](./patio_Dataset.html#all)
+### [all](./patio_Dataset.html#all)
 
 If you want an array of all of the rows associated with the dataset you should use the [all](./patio_Dataset.html#all) method:
 
@@ -127,7 +127,7 @@ User.all().chain(function(users){
 }, errorHandlers);
 ```
 
-###Array methods
+### Array methods
 
 [patio.Dataset](./patio_Dataset.html) has a few array like methods such as
 
@@ -188,7 +188,7 @@ User.map("name").chain(function(userNames){
 }, errorHandler);
 ```
 
-###[selectMap](./patio_Dataset.html#selectMap)  
+### [selectMap](./patio_Dataset.html#selectMap)  
 
 ```
 User.selectMap("name").chain(function(names){
@@ -196,7 +196,7 @@ User.selectMap("name").chain(function(names){
 }, errorHandler);
 ```
 
-###[selectOrderMap](./patio_Dataset.html#selectOrderMap)
+### [selectOrderMap](./patio_Dataset.html#selectOrderMap)
 
 ```
 User.selectOrderMap("name").chain(function(){
@@ -204,7 +204,7 @@ User.selectOrderMap("name").chain(function(){
 }, errorHandler);
 ```
 
-###[toHash](./patio_Dataset.html#toHash)                  
+### [toHash](./patio_Dataset.html#toHash)                  
 
 patio makes it easy to take an SQL query and return it as a plain object, using the [toHash](./patio_Dataset.html) method:
 
@@ -234,7 +234,7 @@ Users.toHash("name").chain(function(){
 }):
 ```
 
-###[selectHash](./patio_Dataset.html#selectHash)
+### [selectHash](./patio_Dataset.html#selectHash)
 **Note**: [toHash](./patio_Dataset.html#toHash) selects all columns. However, [selectHash](./patio_Dataset.html#selectHash) will only select the columns specified.
 
 ```
@@ -244,14 +244,14 @@ User.selectHash("name", "id").chain(function(){
 });
 ```                    
 
-#Filtering
+# Filtering
 
-##[filter](./patio_Dataset.html#filter)
+## [filter](./patio_Dataset.html#filter)
 
 The [filter](./patio_Dataset.html#filter) method is one of the most used methods when querying a dataset. The filter method similar to [where](./patio_Dataset.html#where) except that it will apply the filter to the WHERE or HAVING clause depending on if a HAVING clause should be used.
 
 
-###Filtering With Objects
+### Filtering With Objects
 
 The most common format for providing filters is via an object. In general, patio treats conditions specified with an object as equality or inclusion. What type of condition is used depends on the values in the object.
 
@@ -318,7 +318,7 @@ If you nest hashes for a top level key then each condition will be applied to th
  });
 ```                
 
-###Array of Two Element Arrays
+### Array of Two Element Arrays
 
 If you use an array of two element arrays, it is treated as an Object. The only advantage to using an array of two element arrays is that it allows you to use values other than strings for keys, so you can do:
 
@@ -327,7 +327,7 @@ If you use an array of two element arrays, it is treated as an Object. The only 
  User.filter([["name", /oB$/], [sql.name, /^Bo/]]);
 ```
 
-###Filter Blocks
+### Filter Blocks
 
 Functions can also be provided to the filter method. Functions act as a "virtual" filter.   
 
@@ -347,7 +347,7 @@ User.filter({name : {between : ['K', 'M']}}, function(){
 }); 
 ```
 
-###Strings
+### Strings
 
 If you have a Boolean column in the database you can provide just the column name.
 
@@ -363,7 +363,7 @@ If you have a Boolean column in the database you can provide just the column nam
  User.filter(sql.literal("name < 'A'"));
 ```
 
-###Expressions
+### Expressions
                 
 patio SQL expressions are instances of subclasses of [Epression][./patio_sql_Expression.html].
 
@@ -390,7 +390,7 @@ User.filter(function(){
 });
 ```
   
-###Strings with Placeholders
+### Strings with Placeholders
                 
 patio also supports place holder strings.
 
@@ -414,7 +414,7 @@ You can also use named placeholders with an object, where the named placeholders
 User.filter("name LIKE {name} AND id = {id}", {name : 'B%', id : 1});
 ```
 
-###Literal Strings
+### Literal Strings
 
 You can also provide a literal string using the [literal](./patio_sql.html#.literal)
 
@@ -433,7 +433,7 @@ However, if you are using any untrusted input, you should use placeholders. In g
  User.filter({ id : id}) // Best solution!
 ```
 
-###Inverting filters               
+### Inverting filters               
 
 You can use the [invert](.patio_Dataset.html#invert) method.
 
@@ -456,7 +456,7 @@ User.filter({id : {neq : 5}});
 }).invert();
 ```
 
-###Excluding filters
+### Excluding filters
 You can use [exclude](./patio_Dataset.html#exclude) to invert only specific filters:
 
 ```
@@ -482,7 +482,7 @@ Or to use the NOT LIKE operator:
 User.exclude(sql.name.like('%o%')) 
 ```
 
-###Removing
+### Removing
            
 To remove all existing filters, use the [unfiltered](./patio_Dataset.html#unfiltered) method:
 
@@ -491,7 +491,7 @@ To remove all existing filters, use the [unfiltered](./patio_Dataset.html#unfilt
  User.filter({id : 1}).unfiltered();
 ```
 
-##Ordering
+## Ordering
                 
 To add order to an SQL statement use the [order](./patio_Dataset.html#order) method.
 
@@ -527,7 +527,7 @@ If you want to prepend a column to the existing order use the [orderPrepend](./p
  // SELECT * FROM user ORDER BY name, id
 ```
 
-###Reversing                
+### Reversing                
 
 To reverse the order of a SQL query use the [reverse](./patio_Dataset.html#reverse) method.
 
@@ -550,7 +550,7 @@ This allows for finer grained control of the ordering of columns.
  User.order("name", sql.id.desc());
 ```
 
-###Removing
+### Removing
 
 To remove ordering use the [unordered](./patio_Dataset.html#unordered) method:
 
@@ -560,7 +560,7 @@ To remove ordering use the [unordered](./patio_Dataset.html#unordered) method:
  // SELECT * FROM user
 ```
 
-##Selecting columns
+## Selecting columns
 
 To only return certain columns use the [select](./patio_Dataset.html#select) method.
 
@@ -601,7 +601,7 @@ To remove selected columns and revert to `SELECT *` use the [selectAll](./patio_
  // SELECT * FROM user
 ```
 
-##Distinct
+## Distinct
 
 To add a `DISTINCT` clause to filter out duplicate rows use the [distinct](./patio_Dataset.html#distinct) method.
 
@@ -612,7 +612,7 @@ To add a `DISTINCT` clause to filter out duplicate rows use the [distinct](./pat
 User.distinct().select("name")
 ```
 
-##Limit and Offset
+## Limit and Offset
 
 To limit the number of rows returned use the [limit](./patio_Dataset.html#limit) method.
 
@@ -637,7 +637,7 @@ To remove the LIMIT and OFFSET clause use the [unlimited](./patio_Dataset.html#u
 ```
 
 
-##Grouping
+## Grouping
 
 The GROUP clause is used to results based on the values of a given group of columns. To provide grouping use the [group](./patio_Dataset.html#group) method:
 
@@ -660,7 +660,7 @@ A common use of grouping is to count based on the number of grouped rows, so pat
  User.groupAndCount("userId");
 ```
 
-##Having
+## Having
 
 The HAVING clause filters the results after the grouping has been applied, instead of before.
 
@@ -677,7 +677,7 @@ If you have a HAVING clause then filter will apply the filter to the HAVING clau
  User.groupAndCount("dateOfBirth").having({count : {gte : 10}}).filter({count : {lt : 15}});
 ```
 
-##Where                
+## Where                
 
 Unlike filter, the where method will always affect the WHERE clause:
 
@@ -693,7 +693,7 @@ Both the WHERE clause and the HAVING clause can be removed by using the unfilter
 User.groupAndCount("id").having({count : {gte : 10}}).where({name  : {like : 'A%'}}).unfiltered();
 ```
 
-##Joins
+## Joins
 
 To join a dataset to another table or dataset. The underlying method used is [joinTable](./patio_Dataset.html#joinTable):
 
@@ -722,7 +722,7 @@ joinTable is not typically used directly, but instead by named join methods:
 ```
 
 
-###Table/Dataset to Join
+### Table/Dataset to Join
 
 For the join methods, the first argument is generally the name of the table to which you are joining. However, you can also provide a
 
@@ -738,7 +738,7 @@ For the join methods, the first argument is generally the name of the table to w
  User.join(Blog.filter({title : {lt : 'A'}}), {userId : sql.id});
 ```
 
-###Join Conditions
+### Join Conditions
 
 The second argument to the specialized join methods is the conditions to use when joining, which is similar to a filter expression, with a few minor exceptions.
 
@@ -800,7 +800,7 @@ User.join("blog", [[sql.userId, sql.id], [sql.id, {between : [1, 5]}]]).sql
 
 ```
 
-###USING Joins
+### USING Joins
 
 JOIN ON is the most common type of join condition, however USING is also another valid SQL join expr that patio supports.
 
@@ -811,7 +811,7 @@ JOIN USING is useful when the columns you are using have the same names in both 
  User.join("blog", [sql.userId])
 ```
 
-###NATURAL Joins
+### NATURAL Joins
 
 NATURAL Joins assume that all columns with the same names used for joining, so you do not need to use a join expression.
 
@@ -820,7 +820,7 @@ NATURAL Joins assume that all columns with the same names used for joining, so y
  User.naturalJoin("blog");
 ```
 
-###Join Blocks
+### Join Blocks
 
 The block should accept 3 arguments, the table alias for the table currently being joined, the table alias for the last table joined (or first table), and an array of previous [patio.sql.JoinClause](./patio_sql_JoinClause.html)s.
 
@@ -843,7 +843,7 @@ or you could do this which is the same thing:
 //      ON ((blog.user_id = user.id) AND (blog.title > user.name))
 ```
 
-##From
+## From
 
 The FROM table is typically the first clause populated when creating a dataset. For a standard [patio.Model](./patio_Model.html), the dataset already has the FROM clause populated, and the most common way to create datasets is with the Database from method.
 
@@ -866,7 +866,7 @@ DB.from("user").from("oldUser");
 **Note:** multiple tables in the FROM clause use a cross join by default, so the number of rows will be number of user times the number of old user.
 
 
-##Subselects
+## Subselects
 
 If you want to perform a subselect you can use the [fromSelf](./patio_Dataset.html#fromSelf) method.
 
@@ -887,7 +887,7 @@ Without fromSelf, you are doing the grouping, and limiting the number of grouped
 
 With fromSelf, you are limiting the number of records before grouping. So if the user with the lowest id had 100 blogs, you'd get 1 result, not 100.
 
-##Locking for Update
+## Locking for Update
 
 patio allows you to easily add a FOR UPDATE clause to your queries so that the records returned can't be modified by another query until the current transaction commits. You just use the [forUpdate](./patio_Dataset.html#forUpdate) method:
 
@@ -903,7 +903,7 @@ patio allows you to easily add a FOR UPDATE clause to your queries so that the r
 
 This will ensure that no other connection modifies the row between when you select it and when the transaction ends.
 
-##Custom SQL
+## Custom SQL
 
 patio makes it easy to use custom SQL by providing the [fetch][./patio_Database.html#fetch] method.
 
@@ -928,7 +928,7 @@ You can also use placeholders:
  DB.from("user").withSql("SELECT * FROM user WHERE id = {id}", {id : 5});
 ```
 
-##Checking for Records
+## Checking for Records
 
 To test if there are any records in the database use the isEmpty method
 
@@ -944,7 +944,7 @@ To test if there are any records in the database use the isEmpty method
  },errorHandler);
 
 ```
-##Aggregate Calculations
+## Aggregate Calculations
 
 There are dataset methods for each of the following aggregate calculations:
 

--- a/docs-md/validation.md
+++ b/docs-md/validation.md
@@ -1,4 +1,4 @@
-###[patio.plugins.ValidatorPlugin](./patio_plugins_ValidatorPlugin.html)
+### [patio.plugins.ValidatorPlugin](./patio_plugins_ValidatorPlugin.html)
 
 A validation plugin for patio models. This plugin adds a `validate` method to each [Model](./patio_Model.html)
 class that adds it as a plugin. This plugin does not include most typecast checks as `patio` already checks


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
