### PR TITLE
Use default timestamp type parser

### DIFF
--- a/lib/adapters/postgres.js
+++ b/lib/adapters/postgres.js
@@ -92,18 +92,6 @@ PgTypes.setTypeParser(20, 'text', function (val) {
 });
 
 var timestampOrig = PgTypes.getTypeParser(1114, "text");
-//PgTypes.setTypeParser(25, "text", byteaParser);
-PgTypes.setTypeParser(1114, "text", function (val) {
-    val = String(val);
-    if (!val.match(/\.(\d{0,3})/)) {
-        val += ".000";
-    } else {
-        val = val.replace(/\.(\d{0,3})$/, function (m, m1) {
-            return "." + pad(m1, 3, "0", true);
-        });
-    }
-    return getPatio().stringToTimeStamp(val.toString(), DS.TIMESTAMP_FORMAT).date;
-});
 PgTypes.setTypeParser(1184, "text", function (val) {
     return getPatio().stringToDate(val.toString());
 });


### PR DESCRIPTION
I noticed that timestamps did not include milliseconds when retrieved from the db. I looked at changing the `TIMESTAMP_FORMAT`, but this method will receive two formats one with milliseconds `yyyy-MM-dd HH:mm:ss.SSS` and other times with microseconds `yyyy-MM-dd HH:mm:ss.SSSSSS`.  The  `stringToTimeStamp` falls back to seconds if the date isn't specific. I talked to Doug, and this was added in 2012 when I don't think there was a parser for this type in `pg-types`, which was part of `pg` at the time. It has since been added, so removing this uses the default parser in `pg-types`](https://github.com/brianc/node-pg-types/blob/f320a111e242716dde68f619fdef44969803f039/lib/textParsers.js#L166).

Going to run this against the c2fo tests to make sure everything passes.