### PR TITLE
Dont log error when checking if a table exists

### DIFF
--- a/lib/database/query.js
+++ b/lib/database/query.js
@@ -406,11 +406,8 @@ var Database = define(null, {
          * @return {Promise} a promise resolved with a boolean indicating if the table exists.
          */
         tableExists: function (table, cb) {
-            return this.from(table).first().chain(function () {
-                return true;
-            }, function () {
-                return false;
-            }).classic(cb).promise();
+            const transformedTableName = this.outputIdentifierFunc(table);
+            return this.tables().chain(tables => tables.includes(transformedTableName)).classic(cb).promise();
         },
 
         /**

--- a/test/database/database.test.js
+++ b/test/database/database.test.js
@@ -4,9 +4,6 @@ var it = require('it'),
     Database = patio.Database,
     ConnectionPool = require("../../lib/ConnectionPool"),
     sql = patio.sql,
-    Identifier = sql.Identifier,
-    SQLFunction = sql.SQLFunction,
-    LiteralString = sql.LiteralString,
     helper = require("../helpers/helper"),
     MockDatabase = helper.MockDatabase,
     MockDataset = helper.MockDataset,
@@ -15,19 +12,6 @@ var it = require('it'),
 
 it.describe("Database", function (it) {
 
-    var DummyDataset = comb.define(patio.Dataset, {
-        instance: {
-            first: function () {
-                var ret = new comb.Promise();
-                if (this.__opts.from[0].toString() === "a") {
-                    ret.errback();
-                } else {
-                    ret.callback();
-                }
-                return ret;
-            }
-        }
-    });
     var DummyDatabase = comb.define(patio.Database, {
         instance: {
             constructor: function () {
@@ -61,8 +45,12 @@ it.describe("Database", function (it) {
 
             getters: {
                 dataset: function () {
-                    return new DummyDataset(this);
+                    return new MockDataset(this);
                 }
+            },
+
+            tables: function() {
+                return new comb.Promise().callback(['b']);
             }
         }
     });
@@ -758,7 +746,7 @@ it.describe("Database", function (it) {
             patio.quoteIdentifiers = false;
             db = new DummyDatabase();
         });
-        it.should("try to select the first record from the table's dataset", function () {
+        it.should("returns true if the table is in the list of all tables", function () {
             var a, b;
             return comb.when(
                 db.tableExists("a").chain(function (ret) {
@@ -1228,7 +1216,7 @@ it.describe("Database", function (it) {
             instance: {
                 getters: {
                     dataset: function () {
-                        var ds = new DummyDataset(this);
+                        var ds = new MockDataset(this);
                         ds.get = function () {
                             return this.db.execute(this.select.apply(this, arguments).sql);
                         };


### PR DESCRIPTION
Currently the `tableExists` method logs an error if the table does not exist. This is common when first running migrations, or when only using timestamp prefixed migrations, since the `TimestampMigrator` also checks for the `schema_info` table which is used for integer migrations. For example:

```
Error: QueryError : relation "schema_info" does not exist: SELECT * FROM "schema_info" LIMIT 1
```

This error log is misleading, because it does not stop execution and it is acceptable for the table to be missing.

To fix this I check the list of all tables instead of attempting to query the table.