### PR TITLE
Use a falsy statement with primitive types (true = false) instead of …

### DIFF
--- a/lib/dataset/sql.js
+++ b/lib/dataset/sql.js
@@ -752,8 +752,8 @@ define({
                 if (colArray) {
                     if (emptyValArray) {
                         if (op === "IN") {
-                            // if the array is empty, we return an expression that will be falsy
-                            return "(true = false)";
+                            // if the array is empty, we return an expression that will be false
+                            return this.literal({1: 0});
                         } else {
                             return this.literal({1: 1});
                         }
@@ -776,8 +776,8 @@ define({
                 else {
                     if (emptyValArray) {
                         if (op === "IN") {
-                            // if the array is empty, we return an expression that will be falsy
-                            return "(true = false)";
+                            // if the array is empty, we return an expression that will be false
+                            return this.literal({1: 0});
                         } else {
                             return this.literal({1: 1});
                         }

--- a/test/dataset/query.test.js
+++ b/test/dataset/query.test.js
@@ -318,10 +318,10 @@ it.describe("Dataset queries", function (it) {
 
         it.should("handle all types of IN/NOT IN queries", function () {
             assert.equal(dataset.filter({id: d1.select("id")}).sql, "SELECT * FROM test WHERE (id IN (SELECT id FROM test WHERE (region = 'Asia')))");
-            assert.equal(dataset.filter({id: []}).sql, "SELECT * FROM test WHERE (true = false)");
+            assert.equal(dataset.filter({id: []}).sql, "SELECT * FROM test WHERE (1 = 0)");
             assert.equal(dataset.filter({id: [1, 2]}).sql, "SELECT * FROM test WHERE (id IN (1, 2))");
             assert.equal(dataset.filter({"id1,id2": d1.select("id1", "id2")}).sql, "SELECT * FROM test WHERE ((id1, id2) IN (SELECT id1, id2 FROM test WHERE (region = 'Asia')))");
-            assert.equal(dataset.filter({"id1,id2": []}).sql, "SELECT * FROM test WHERE (true = false)");
+            assert.equal(dataset.filter({"id1,id2": []}).sql, "SELECT * FROM test WHERE (1 = 0)");
             assert.equal(dataset.filter({
                 "id1,id2": [
                     [1, 2],


### PR DESCRIPTION
…(col != col) for empty in caluse situations. This prevents the need to actually look up the column values from cache/disk.

This changes the sql generated for empty inclauses. For example:
```js
db.from("test")
.filter({
    id: []
}).all();
// Current Result:
// SELECT * FROM test WHERE (id != id)
// After change
// SELECT * FROM test WHERE (1 = 0)
```
These statements should both be logically equivalent, but there is a performance difference because while we know that `(id != id)` is always going to be false, postgres doesn't and still does an `id` lookup and comparison to itself. 

Changing this to `(1 = 0)` will not cause any pages to be scanned. Postgres is also smart enough to know that expressions like `(id = 123 AND 1 = 0)` will always be false so it won't lookup id in this case either. 

