### PR TITLE
Handle empty IN clause with quoteIdentifiers=true

### DIFF
--- a/lib/dataset/sql.js
+++ b/lib/dataset/sql.js
@@ -749,15 +749,18 @@ define({
                     valArray = true;
                     emptyValArray = vals.length === 0;
                 }
+
+                if (emptyValArray) {
+                    if (op === "IN") {
+                        // if the array is empty, we return an expression that will be false
+                        return new BooleanExpression("EQ", 1, 0);
+                    } else {
+                        return this.literal({1: 1});
+                    }
+                }
+
                 if (colArray) {
-                    if (emptyValArray) {
-                        if (op === "IN") {
-                            // if the array is empty, we return an expression that will be false
-                            return this.literal({1: 0});
-                        } else {
-                            return this.literal({1: 1});
-                        }
-                    } else if (!this.supportsMultipleColumnIn) {
+                   if (!this.supportsMultipleColumnIn) {
                         if (valArray) {
                             var expr = BooleanExpression.fromArgs(["OR"].concat(vals.map(function (vs) {
                                 return BooleanExpression.fromValuePairs(array.zip(cols, vs));
@@ -774,17 +777,8 @@ define({
                     }
                 }
                 else {
-                    if (emptyValArray) {
-                        if (op === "IN") {
-                            // if the array is empty, we return an expression that will be false
-                            return this.literal({1: 0});
-                        } else {
-                            return this.literal({1: 1});
-                        }
-                    } else {
-                        return format("(%s %s %s)", isString(cols) ? cols : this.literal(cols),
+                    return format("(%s %s %s)", isString(cols) ? cols : this.literal(cols),
                             ComplexExpression.IN_OPERATORS[op], this.literal(vals));
-                    }
                 }
             } else if ((newOp = this._static.TWO_ARITY_OPERATORS[op]) != null) {
                 l = args[0];

--- a/test/dataset/query.test.js
+++ b/test/dataset/query.test.js
@@ -316,6 +316,10 @@ it.describe("Dataset queries", function (it) {
             assert.equal(dataset.filter('gdp > ?', d1.select(new SQLFunction("avg", "gdp"))).sql, "SELECT * FROM test WHERE (gdp > (SELECT avg(gdp) FROM test WHERE (region = 'Asia')))");
         });
 
+        it.should("handle IN in queries with value as empty array and quoteIdentifiers=true", function () {
+            assert.equal(new Dataset({ quoteIdentifiers: true }).from("test").filter({id: []}).deleteSql, 'DELETE FROM "test" WHERE (1 = 0)');
+        });
+
         it.should("handle all types of IN/NOT IN queries", function () {
             assert.equal(dataset.filter({id: d1.select("id")}).sql, "SELECT * FROM test WHERE (id IN (SELECT id FROM test WHERE (region = 'Asia')))");
             assert.equal(dataset.filter({id: []}).sql, "SELECT * FROM test WHERE (1 = 0)");


### PR DESCRIPTION
This is a fix to handle cases where the option`quoteIdentifiers=true` so that it doesn't quote the 1 `("1" = 0)`.